### PR TITLE
Escape sequence in exchange name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Changelog for rabtap
 
+## v1.18 (2019-07-05)
+
+* fix: tap: allow colons in exchange names by escaping them (`exchange\\:with\\:colon`).
+  Fixes #13.
+
 ## v1.17 (2019-06-13)
 
 * Timestamp when message was received by rabtap now stored in JSON format

--- a/README.md
+++ b/README.md
@@ -259,7 +259,9 @@ The `tap` command allows to tap exchanges and transparently receives messages
 sent to the exchanges.  Rabtap automatically reconnects on connections
 failures. The syntax of the `tap` command is `rabtap tap [--uri URI] EXCHANGES`
 where the `EXCHANGES` argument specifies the exchanges and binding keys to use.
-The `EXCHANGES` argument is of the form `EXCHANGE:[KEY][,EXCHANGE:[KEY]]*`.
+The `EXCHANGES` argument is of the form `EXCHANGE:[KEY][,EXCHANGE:[KEY]]*`. If
+the exchange name contains a colon, use `\\:` to escape it, e.g.
+`myexchange\\:with\\:colons:KEY`.
 
 The acutal format of the binding key depends on the exchange type (e.g.
 direct, topic, headers) and is described in the [RabbitMQ

--- a/pkg/tap_configuration.go
+++ b/pkg/tap_configuration.go
@@ -17,15 +17,51 @@ type ExchangeConfiguration struct {
 	BindingKey string
 }
 
+// unescapeStr reutrns a string with all '\' characters removed from the
+// given string
+func unescapeStr(s string) string {
+	res := ""
+	inEscape := false
+	for _, c := range s {
+		if c == '\\' && !inEscape {
+			inEscape = true
+		} else {
+			inEscape = false
+			res += string(c)
+		}
+	}
+	return res
+}
+
+// splitExchangeAndBinding splits a string of the form "exchange:binding"
+// and return exchange and binding as string. A colon can be escaped with
+// \: if it is part of the exchange or binding string, e.g.
+// splitExchangeAndBinding("ex\\:change:binding") -> ("ex:change", "binding", nil)
+func splitExchangeAndBinding(exchangeAndBinding string) (string, string, error) {
+	inEscape := false
+	pos := -1
+	for i, c := range exchangeAndBinding {
+		if c == ':' && !inEscape {
+			pos = i
+			break
+		}
+		inEscape = (c == '\\')
+	}
+	if pos == -1 {
+		return "", "", errors.New("expected format `exchange`:`binding`, but got `" +
+			exchangeAndBinding + "`")
+	}
+	return unescapeStr(exchangeAndBinding[:pos]), unescapeStr(exchangeAndBinding[pos+1:]), nil
+}
+
 // NewExchangeConfiguration returns a pointer to a newly created
 // ExchangeConfiguration object
 func NewExchangeConfiguration(exchangeAndBindingStr string) (*ExchangeConfiguration, error) {
-	exchangeAndBinding := strings.Split(exchangeAndBindingStr, ":")
-	if len(exchangeAndBinding) != 2 {
-		return nil, errors.New("expected format `exchange`:`binding`, but got `" +
-			exchangeAndBindingStr + "`")
+	exchange, binding, err := splitExchangeAndBinding(exchangeAndBindingStr)
+	if err != nil {
+		return nil, err
 	}
-	return &ExchangeConfiguration{exchangeAndBinding[0], exchangeAndBinding[1]}, nil
+	return &ExchangeConfiguration{exchange, binding}, nil
 }
 
 // TapConfiguration holds the set of ExchangeCOnfigurations to tap to for a

--- a/pkg/tap_configuration_test.go
+++ b/pkg/tap_configuration_test.go
@@ -8,6 +8,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestUnescapeString(t *testing.T) {
+	assert.Equal(t, "", unescapeStr(""))
+	assert.Equal(t, "a", unescapeStr("a"))
+	assert.Equal(t, "", unescapeStr("\\"))
+	assert.Equal(t, "\\", unescapeStr("\\\\"))
+	assert.Equal(t, "a:", unescapeStr("a\\:"))
+}
+
+func TestSplitExchangeAndBindingSimpleCaseProceeds(t *testing.T) {
+	e, b, err := splitExchangeAndBinding("abc:def")
+	assert.Nil(t, err)
+	assert.Equal(t, "abc", e)
+	assert.Equal(t, "def", b)
+}
+
+func TestSplitExchangeAndBindingHonorsEscapedColons(t *testing.T) {
+	e, b, err := splitExchangeAndBinding("abc\\:xyz\\:123:def\\:jkl:")
+	assert.Nil(t, err)
+	assert.Equal(t, "abc:xyz:123", e)
+	assert.Equal(t, "def:jkl:", b)
+}
+
+func TestSplitExchangeAndBindingRaisesErrorMissingKey(t *testing.T) {
+	_, _, err := splitExchangeAndBinding("abcdef")
+	assert.NotNil(t, err)
+}
+
 func TestNewTapConfiguration(t *testing.T) {
 
 	tc, err := NewTapConfiguration("uri", "e1:b1,e2:b2")


### PR DESCRIPTION
Allow colons in exchange name of tap command, e.g.  `exchange\\:with\\:colons:key`. Fixes #13.