### PR TITLE
Avoid blocking write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 
 # Changelog for rabtap
 
-## v1.20 (2019-08-xx)
+## v1.20 (2019-08-30)
 
-* fix: typo in connection node of dot output
+* fix: avoid blocking write during tap, subscribe which can lead to ctrl+c
+  to not work when e.g. ctrl+s is pressed during tap or subscribe.
+* refactorings
 
 ## v1.19 (2019-08-18)
 

--- a/pkg/amqp_message_loop.go
+++ b/pkg/amqp_message_loop.go
@@ -1,0 +1,44 @@
+// Copyright (C) 2017 Jan Delgado
+
+package rabtap
+
+import (
+	"context"
+	"time"
+
+	"github.com/streadway/amqp"
+)
+
+// amqpMessageLoop forwards incoming amqp messages from an "in" chan to an "out"
+// chan, transforming them into TapMessage objects. Can be terminated
+// using provided ctx or by closing the in chan.
+func amqpMessageLoop(ctx context.Context,
+	out TapChannel, in <-chan interface{}) ReconnectAction {
+
+	for {
+		select {
+		case message, more := <-in:
+			if !more {
+				return doReconnect
+			}
+			// in is chan interface{} because we use FanIn.Ch
+			amqpMessage, ok := message.(amqp.Delivery)
+
+			if !ok {
+				panic("amqp.Delivery expected")
+			}
+
+			received := time.Now()
+			// Avoid blocking write to out when e.g. on the other end of the
+			// channel the user pressed Ctrl+S to stop console output
+			select {
+			case out <- NewTapMessage(&amqpMessage, received):
+			case <-ctx.Done():
+				return doNotReconnect
+			}
+
+		case <-ctx.Done():
+			return doNotReconnect
+		}
+	}
+}

--- a/pkg/amqp_message_loop_test.go
+++ b/pkg/amqp_message_loop_test.go
@@ -1,0 +1,100 @@
+package rabtap
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/streadway/amqp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAmqpMessageLoopForwardsMessage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	out := make(TapChannel)
+	in := make(chan interface{})
+	done := make(chan bool)
+
+	go func() {
+		assert.Panics(t, func() { amqpMessageLoop(ctx, out, in) }, "did not panic")
+		done <- true
+	}()
+
+	// we expect amqpMessageLoop to panic when a non amqp.Delivery is passed in
+	in <- 1337
+
+	cancel()
+
+	select {
+	case result := <-done:
+		assert.Equal(t, true, result)
+	case <-time.After(2 * time.Second):
+		assert.Fail(t, "amqpMessageLoop() did not terminate")
+	}
+}
+
+func TestAmqpMessageLoopTerminatesWhenInputChannelIsClosed(t *testing.T) {
+	ctx := context.Background()
+	out := make(TapChannel)
+	in := make(chan interface{})
+	done := make(chan ReconnectAction)
+
+	go func() {
+		done <- amqpMessageLoop(ctx, out, in)
+	}()
+
+	close(in)
+
+	select {
+	case result := <-done:
+		assert.Equal(t, doReconnect, result)
+	case <-time.After(2 * time.Second):
+		assert.Fail(t, "amqpMessageLoop() did not terminate")
+	}
+}
+
+func TestAmqpMessageLoopCancelBlockingWrite(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	out := make(TapChannel)
+	in := make(chan interface{}, 5)
+	done := make(chan ReconnectAction)
+
+	go func() {
+		done <- amqpMessageLoop(ctx, out, in)
+	}()
+
+	in <- amqp.Delivery{}
+	// this second write blocks the write in the messageloop
+	in <- amqp.Delivery{}
+
+	cancel()
+
+	select {
+	case result := <-done:
+		assert.Equal(t, doNotReconnect, result)
+	case <-time.After(2 * time.Second):
+		assert.Fail(t, "amqpMessageLoop() did not terminate")
+	}
+
+}
+
+func TestAmqpMessageLoopCancelBlockingRead(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	out := make(TapChannel)
+	in := make(chan interface{})
+	done := make(chan ReconnectAction)
+
+	go func() {
+		done <- amqpMessageLoop(ctx, out, in)
+	}()
+
+	cancel()
+
+	select {
+	case result := <-done:
+		assert.Equal(t, doNotReconnect, result)
+	case <-time.After(2 * time.Second):
+		assert.Fail(t, "amqpMessageLoop() did not terminate")
+	}
+
+}

--- a/pkg/tap.go
+++ b/pkg/tap.go
@@ -57,7 +57,7 @@ func (s *AmqpTap) createWorkerFunc(
 		fanin := NewFanin(amqpChs)
 		defer func() { _ = fanin.Stop() }()
 
-		action := s.messageLoop(ctx, tapCh, fanin)
+		action := amqpMessageLoop(ctx, tapCh, fanin.Ch)
 
 		return action, nil
 	}


### PR DESCRIPTION
 * avoid blocking write during tap, subscribe which can lead to ctrl+c to not work when e.g. ctrl+s is pressed during tap or subscribe.
* Refactorings