### PR TITLE
Index out of range panic upon encountering an empty string

### DIFF
--- a/cmd/rabtap/json_message_formatter.go
+++ b/cmd/rabtap/json_message_formatter.go
@@ -20,12 +20,15 @@ var (
 )
 
 // Format validates and formats a message in JSON format. The body can be a
-// simple JSON object or an array of JSON objecs. If the message is not valid
-// JSON, it will returned unformatted as-is.
+// simple JSON object or an array of JSON objects. If the message is not valid
+// JSON, it will be returned unformatted as-is.
 func (s JSONMessageFormatter) Format(message rabtap.TapMessage) string {
 
 	var formatted []byte
 	originalMessage := strings.TrimSpace(string(message.AmqpMessage.Body))
+	if len(originalMessage) == 0 {
+		return string(message.AmqpMessage.Body)
+	}
 	if originalMessage[0] == '[' {
 		// try to unmarshal array to JSON objects
 		var arrayJSONObj []map[string]interface{}

--- a/cmd/rabtap/json_message_formatter_test.go
+++ b/cmd/rabtap/json_message_formatter_test.go
@@ -48,3 +48,13 @@ func TestJSONFormatterValidObject(t *testing.T) {
 	formattedMessage := JSONMessageFormatter{}.Format(rabtap.NewTapMessage(&message, time.Now()))
 	assert.Equal(t, "{\n  \"a\": 1\n}", formattedMessage)
 }
+
+func TestJSONFormatterEmptyValue(t *testing.T) {
+	// An empty buffer effectively should be returned unmodified
+	message := amqp.Delivery{
+		Body: []byte(""),
+	}
+	formattedMessage := JSONMessageFormatter{}.Format(rabtap.NewTapMessage(&message, time.Now()))
+	// message is expected to be returned untouched
+	assert.Equal(t, "", formattedMessage)
+}


### PR DESCRIPTION
Hi, I hope you will find this patch useful/acceptable. It looks like there's no handling, at least in master of empty string values. I observed a panic like this one, only to later realize I was producing an empty value. It feels like the program needs to be more robust to this sort of thing.

```
DEBUG[0010] subscribe: messageReceiveLoop: new message rabtap.TapMessage{AmqpMessage:(*amqp.Delivery)(0xc000282140), ReceivedTimestamp:time.Time{wall:0xbf58d195a9233448, ext:10030160565, loc:(*time.Location)(0x17d4a60)}}
panic: runtime error: index out of range

goroutine 55 [running]:
main.JSONMessageFormatter.Format(0xc000282140, 0xbf58d195a9233448, 0x255d81ab5, 0x17d4a60, 0xc0000ba5a0, 0xc000080310)
	/Users/szaydel/go/src/github.com/jandelgado/cmd/rabtap/json_message_formatter.go:31 +0x4ba
main.PrettyPrintMessage(0x14f6740, 0xc0000aa000, 0xc000282140, 0xbf58d195a9233448, 0x255d81ab5, 0x17d4a60, 0x0, 0xc00007e478, 0x1052fe0)
	/Users/szaydel/go/src/github.com/jandelgado/cmd/rabtap/message_printer.go:72 +0x10f
main.createMessageReceiveFuncRaw.func1(0xc000282140, 0xbf58d195a9233448, 0x255d81ab5, 0x17d4a60, 0x0, 0x0)
	/Users/szaydel/go/src/github.com/jandelgado/cmd/rabtap/subscribe.go:76 +0x8a
main.messageReceiveLoop.func1(0xc00007e420, 0xc0001bc000)
	/Users/szaydel/go/src/github.com/jandelgado/cmd/rabtap/subscribe.go:39 +0x77
created by main.messageReceiveLoop
	/Users/szaydel/go/src/github.com/jandelgado/cmd/rabtap/subscribe.go:36 +0x243
```