### PR TITLE
workaround for RabbitMQ API returning int or "undefined" (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Changelog for rabtap
 
+## v1.25 (2020-10-30)
+
+* fix: rabtap info: workaround for RabbitMQ API returning an `"undefined"`
+  string where an integer was expected (#47)
+
 ## v1.24 (2020-09-28)
 
 * new: support TLS client certificates (contributed by Francois Gouteroux)

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ toxiproxy-cmd:
 
 # run rabbitmq server for integration test using docker container.
 run-broker:
-	podman run -ti --rm -p 5672:5672 -p 15672:15672 rabbitmq:3-management
+	podman run -ti --rm -p 5672:5672 -p 15672:15672 rabbitmq:3.8.5-management
 
 dist-clean: clean
 	rm -f *.out $(BINARY_WIN64) $(BINARY_LINUX64) $(BINARY_DARWIN64)


### PR DESCRIPTION
Fixes #47 where RabbitMQ inconsitently returns either an integer or the string `"undefined"` in the Consumers API endpoint.