### PR TITLE
Add queue type and utilisation to info command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for rabtap
 
+## v1.31 (2021-11-07)
+
+* new: show queue utilisation and type (e.g. classic, quorum, stream) to info
+  command
+* new: build rabtap for more targets using goreleaser
+  
 ## v1.30 (2021-10-13)
 
 * new: support header based routing (pub, queue bind, queue unbind)

--- a/cmd/rabtap/cmd_info_test.go
+++ b/cmd/rabtap/cmd_info_test.go
@@ -65,20 +65,20 @@ func Example_cmdInfoByExchangeInTextFormat() {
 	//     ├── amq.rabbitmq.trace (exchange, type 'topic', [D|I])
 	//     ├── amq.topic (exchange, type 'topic', [D])
 	//     ├── test-direct (exchange, type 'direct', [D|AD|I])
-	//     │   ├── direct-q1 (queue, key='direct-q1', running, [D])
+	//     │   ├── direct-q1 (queue(classic), key='direct-q1', running, [D])
 	//     │   │   ├── some_consumer (consumer user='guest', prefetch=0, chan='172.17.0.1:40874 -> 172.17.0.2:5672 (1)')
 	//     │   │   │   └── '172.17.0.1:40874 -> 172.17.0.2:5672' (connection client='https://github.com/streadway/amqp', host='172.17.0.2:5672', peer='172.17.0.1:40874')
 	//     │   │   └── another_consumer w/ faulty channel (consumer user='', prefetch=0, chan='')
-	//     │   └── direct-q2 (queue, key='direct-q2', running, [D])
+	//     │   └── direct-q2 (queue(classic), key='direct-q2', running, [D])
 	//     ├── test-fanout (exchange, type 'fanout', [D])
-	//     │   ├── fanout-q1 (queue, idle since 2017-05-25 19:14:32, [D])
-	//     │   └── fanout-q2 (queue, idle since 2017-05-25 19:14:32, [D])
+	//     │   ├── fanout-q1 (queue(classic), idle since 2017-05-25 19:14:32, [D])
+	//     │   └── fanout-q2 (queue(classic), idle since 2017-05-25 19:14:32, [D])
 	//     ├── test-headers (exchange, type 'headers', [D|AD])
-	//     │   ├── header-q1 (queue, key='headers-q1', idle since 2017-05-25 19:14:53, [D])
-	//     │   └── header-q2 (queue, key='headers-q2', idle since 2017-05-25 19:14:47, [D])
+	//     │   ├── header-q1 (queue(classic), key='headers-q1', idle since 2017-05-25 19:14:53, [D])
+	//     │   └── header-q2 (queue(classic), key='headers-q2', idle since 2017-05-25 19:14:47, [D])
 	//     └── test-topic (exchange, type 'topic', [D])
-	//         ├── topic-q1 (queue, key='topic-q1', idle since 2017-05-25 19:14:17, [D|AD|EX])
-	//         ├── topic-q2 (queue, key='topic-q2', idle since 2017-05-25 19:14:21, [D])
+	//         ├── topic-q1 (queue(classic), key='topic-q1', idle since 2017-05-25 19:14:17, [D|AD|EX])
+	//         ├── topic-q2 (queue(classic), key='topic-q2', idle since 2017-05-25 19:14:21, [D])
 	//         └── test-topic (exchange, type 'topic', [D])
 
 }
@@ -112,7 +112,7 @@ func Example_cmdInfoByConnectionInTextFormat() {
 	// └── Vhost /
 	//     └── '172.17.0.1:40874 -> 172.17.0.2:5672' (connection client='https://github.com/streadway/amqp', host='172.17.0.2:5672', peer='172.17.0.1:40874')
 	//         └── some_consumer (consumer user='guest', prefetch=0, chan='172.17.0.1:40874 -> 172.17.0.2:5672 (1)')
-	//             └── direct-q1 (queue, running, [D])
+	//             └── direct-q1 (queue(classic), running, [D])
 }
 
 const expectedResultDotByExchange = `graph broker {

--- a/cmd/rabtap/color_printer.go
+++ b/cmd/rabtap/color_printer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"text/template"
 
 	"github.com/fatih/color"
 	"github.com/mattn/go-colorable"
@@ -41,8 +42,8 @@ type ColorPrinter struct {
 }
 
 // GetFuncMap returns a function map that can be used in a template.
-func (s ColorPrinter) GetFuncMap() map[string]interface{} {
-	return map[string]interface{}{
+func (s ColorPrinter) GetFuncMap() template.FuncMap {
+	return template.FuncMap{
 		"QueueColor":      s.Queue,
 		"ConnectionColor": s.Connection,
 		"ChannelColor":    s.Channel,

--- a/cmd/rabtap/rabtap_template_funcs.go
+++ b/cmd/rabtap/rabtap_template_funcs.go
@@ -1,0 +1,24 @@
+// templating functions for rabtap
+// (c) copyright 2021 by Jan Delgado
+package main
+
+import (
+	"math"
+	"text/template"
+)
+
+var RabtapTemplateFuncs = rabtapTemplateFuncs{}.GetFuncMap()
+
+type rabtapTemplateFuncs struct {
+}
+
+// toPercent converts the given float value to a rounded int percentage value
+func (s rabtapTemplateFuncs) toPercent(x float64) int {
+	return int(math.Round(x * 100.))
+}
+
+func (s rabtapTemplateFuncs) GetFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"ToPercent": s.toPercent,
+	}
+}

--- a/cmd/rabtap/rabtap_template_funcs_test.go
+++ b/cmd/rabtap/rabtap_template_funcs_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFloatsAreConvertedIntoPercentageValues(t *testing.T) {
+	f := rabtapTemplateFuncs{}
+
+	assert.Equal(t, 0, f.toPercent(0.))
+	assert.Equal(t, 99, f.toPercent(0.99))
+	assert.Equal(t, 100, f.toPercent(0.999))
+	assert.Equal(t, 100, f.toPercent(1.0))
+}

--- a/cmd/rabtap/template.go
+++ b/cmd/rabtap/template.go
@@ -1,10 +1,22 @@
-// Copyright (C) 2017-2019 Jan Delgado
+// rabtap templating
+// Copyright (C) 2017-2021 Jan Delgado
 package main
 
 import (
 	"bytes"
 	"text/template"
 )
+
+// MergeTemplateFuncs merges the given list of template funcs into a single one
+func MergeTemplateFuncs(maps ...template.FuncMap) template.FuncMap {
+	res := template.FuncMap{}
+	for _, m := range maps {
+		for k, v := range m {
+			res[k] = v
+		}
+	}
+	return res
+}
 
 // resolveTemplate resolves a template for use in the broker info printer,
 // with support for colored output. name is just an informational name

--- a/inttest/rabbitmq/docker-compose.yml
+++ b/inttest/rabbitmq/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   rabbitmq:
-     image: rabbitmq:3.9.8-management-alpine
+     image: rabbitmq:3.8-management-alpine
      volumes:
        - ./definitions.json:/etc/rabbitmq/definitions.json:z
        - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:z

--- a/pkg/rabbitmq_rest_client.go
+++ b/pkg/rabbitmq_rest_client.go
@@ -438,6 +438,7 @@ type RabbitQueue struct {
 	Durable              bool   `json:"durable"`
 	Vhost                string `json:"vhost"`
 	Name                 string `json:"name"`
+	Type                 string `json:"type"`
 	MessageBytesPagedOut int    `json:"message_bytes_paged_out"`
 	MessagesPagedOut     int    `json:"messages_paged_out"`
 	BackingQueueStatus   struct {
@@ -477,8 +478,8 @@ type RabbitQueue struct {
 	Consumers int `json:"consumers"`
 	//	ExclusiveConsumerTag interface{} `json:"exclusive_consumer_tag"`
 	//	Policy               interface{} `json:"policy"`
-	//	ConsumerUtilisation  interface{} `json:"consumer_utilisation"`
-	// TODO use cusom marshaller and parese into time.Time
+	ConsumerUtilisation float64 `json:"consumer_utilisation"`
+	// TODO use custom marshaller and parse into time.Time
 	IdleSince string `json:"idle_since"`
 	Memory    int    `json:"memory"`
 }

--- a/pkg/testcommon/rabbitmq_rest_api_mock.go
+++ b/pkg/testcommon/rabbitmq_rest_api_mock.go
@@ -450,6 +450,7 @@ const (
         "durable": true,
         "vhost": "/",
         "name": "direct-q1",
+		"type": "classic",
         "message_bytes_paged_out": 0,
         "messages_paged_out": 0,
         "backing_queue_status": {
@@ -524,6 +525,7 @@ const (
         "durable": true,
         "vhost": "/",
         "name": "direct-q2",
+		"Type": "classic",
         "message_bytes_paged_out": 0,
         "messages_paged_out": 0,
         "backing_queue_status": {
@@ -598,6 +600,7 @@ const (
         "durable": true,
         "vhost": "/",
         "name": "fanout-q1",
+		"type": "classic",
         "message_bytes_paged_out": 0,
         "messages_paged_out": 0,
         "backing_queue_status": {
@@ -673,6 +676,7 @@ const (
         "durable": true,
         "vhost": "/",
         "name": "fanout-q2",
+		"type": "classic",
         "message_bytes_paged_out": 0,
         "messages_paged_out": 0,
         "backing_queue_status": {
@@ -748,6 +752,7 @@ const (
         "durable": true,
         "vhost": "/",
         "name": "header-q1",
+		"type": "classic",
         "message_bytes_paged_out": 0,
         "messages_paged_out": 0,
         "backing_queue_status": {
@@ -823,6 +828,7 @@ const (
         "durable": true,
         "vhost": "/",
         "name": "header-q2",
+		"type": "classic",
         "message_bytes_paged_out": 0,
         "messages_paged_out": 0,
         "backing_queue_status": {
@@ -898,6 +904,7 @@ const (
         "durable": true,
         "vhost": "/",
         "name": "topic-q1",
+		"type": "classic",
         "message_bytes_paged_out": 0,
         "messages_paged_out": 0,
         "backing_queue_status": {
@@ -973,6 +980,7 @@ const (
         "durable": true,
         "vhost": "/",
         "name": "topic-q2",
+		"type": "classic",
         "message_bytes_paged_out": 0,
         "messages_paged_out": 0,
         "backing_queue_status": {


### PR DESCRIPTION
Queue type and consumer utilisation are added to the queue info, e.g.

```
 └── test-topic (exchange, type 'topic', in=(3370, 0.0/s) msg, out=(3370, 0.0/s) msg, [AD])
        ├── test-q-test-topic-0 (queue(classic), key='test-q-test-topic-0',0 cons, (674, 0.0/s) msg, (674, 0.0/s) msg ready, 0% utl, idle since 2021-11-07 19:02:29, [])
```
