### PR TITLE
pass optional args to queue and exchange create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog for rabtap
 
-## v1.32 (2021-11-xx)
+## v1.33 (2021-11-14)
+
+* new: specify multiple `--args=key=value` options to pass additional argzuments
+       to the queue and exchange create functions.
+       
+## v1.32 (2021-11-13)
 
 * new: `--limit=NUM` option in sub and tap command to limit the number
       of messages to receive.

--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ http://localhost:15672/api (broker ver='3.7.8', mgmt ver='3.7.8', cluster='rabbi
     │   └── myqueue (queue, key='myqueue', idle since 2018-12-07 20:46:15, [])
     :
     └── amq.topic (exchange, type 'topic', [D])
+$ rabtap queue purge myqueue
 $ rabtap queue rm myqueue
 $ rabtap info
 http://localhost:15672/api (broker ver='3.7.8', mgmt ver='3.7.8', cluster='rabbit@b2fe3b3b6826')
@@ -623,12 +624,15 @@ http://localhost:15672/api (broker ver='3.7.8', mgmt ver='3.7.8', cluster='rabbi
     └── amq.topic (exchange, type 'topic', [D])
 ```
 
-Additionally use the `purge` command to remove all elements from a queue, e.g.
+The `create` commands allows to specify additional arguments to be passed to
+RabbitMQ using the `--args=key=value` syntax. This allows for example to specify
+the queue type or mode:
 
-```
-$ rabtap queue purge myqueue
-```
-
+* `rabtap queue create quorum_queue --args=x-queue-type=quorum --durable` - 
+  create a quorum queue named `quorum_queue`
+* `rabtap queue create lazy_queue --args=x-queue-mode=lazy` - create a lazy
+  queue named `lazy_queue`
+  
 ## JSON message format
 
 When using the `--format json` option, messages are print/read as a stream of JSON

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ and exchanges, inspect broker.
         * [Publish messages](#publish-messages)
         * [Poor mans shovel](#poor-mans-shovel)
         * [Close connection](#close-connection)
+        * [Exchange commands](#exchange-commands)
         * [Queue commands](#queue-commands)
 * [JSON message format](#json-message-format)
 * [Filtering output of info command](#filtering-output-of-info-command)
@@ -585,9 +586,25 @@ http://localhost:15672/api (broker ver='3.6.9', mgmt ver='3.6.9', cluster='rabbi
 $ rabtap conn close '172.17.0.1:59228 -> 172.17.0.2:5672'
 ```
 
+#### Exchange commands
+
+The `exchange` command is used to create and remove exchanges:
+
+```console
+$ rabtap exchange create myexchange --type topic
+$ rabtap exchange rm myexchange
+```
+
+The `create` commands allows to specify additional arguments to be passed to
+RabbitMQ using the `--args=key=value` syntax:
+
+```console
+$ rabtap exchange create myexchange --type topic --args=alternate-exchange=myae
+```
+
 #### Queue commands
 
-The `queue` command can be used to easily create, remove, bind or unbind queues:
+The `queue` command is used to create, remove, bind or unbind queues:
 
 ```console
 $ rabtap queue create myqueue

--- a/cmd/rabtap/cmd_exchange.go
+++ b/cmd/rabtap/cmd_exchange.go
@@ -19,6 +19,7 @@ type CmdExchangeCreateArg struct {
 	exchangeType string
 	durable      bool
 	autodelete   bool
+	args         rabtap.KeyValueMap
 	tlsConfig    *tls.Config
 }
 
@@ -27,10 +28,10 @@ func cmdExchangeCreate(cmd CmdExchangeCreateArg) {
 	failOnError(rabtap.SimpleAmqpConnector(cmd.amqpURL,
 		cmd.tlsConfig,
 		func(session rabtap.Session) error {
-			log.Debugf("creating exchange %s with type %s",
-				cmd.exchange, cmd.exchangeType)
+			log.Debugf("creating exchange %s with type %s, args=%v",
+				cmd.exchange, cmd.exchangeType, cmd.args)
 			return rabtap.CreateExchange(session, cmd.exchange, cmd.exchangeType,
-				cmd.durable, cmd.autodelete)
+				cmd.durable, cmd.autodelete, rabtap.ToAMQPTable(cmd.args))
 		}), "create exchange failed", os.Exit)
 }
 

--- a/cmd/rabtap/command_line_test.go
+++ b/cmd/rabtap/command_line_test.go
@@ -483,12 +483,13 @@ func TestCliSubCmdSaveToDir(t *testing.T) {
 
 func TestCliCreateQueue(t *testing.T) {
 	args, err := ParseCommandLineArgs(
-		[]string{"queue", "create", "name", "--uri=uri"})
+		[]string{"queue", "create", "name", "--uri=uri", "--args=x=y"})
 
 	assert.Nil(t, err)
 	assert.Equal(t, QueueCreateCmd, args.Cmd)
 	assert.Equal(t, "name", args.QueueName)
 	assertEqualURL(t, "uri", args.AMQPURL)
+	assert.Equal(t, map[string]string{"x": "y"}, args.Args)
 	assert.False(t, args.Durable)
 	assert.False(t, args.Autodelete)
 }
@@ -547,7 +548,7 @@ func TestCliBindQueueWithBindingKey(t *testing.T) {
 	assert.Equal(t, "queuename", args.QueueName)
 	assert.Equal(t, "exchangename", args.ExchangeName)
 	assert.Equal(t, "key", args.QueueBindingKey)
-	assert.Equal(t, map[string]string{}, args.Headers)
+	assert.Equal(t, map[string]string{}, args.Args)
 	assert.Equal(t, HeaderNone, args.HeaderMode)
 	assertEqualURL(t, "uri", args.AMQPURL)
 }
@@ -562,14 +563,14 @@ func TestCliBindQueueWithHeaders(t *testing.T) {
 	assert.Equal(t, "queuename", args.QueueName)
 	assert.Equal(t, "exchangename", args.ExchangeName)
 	assert.Equal(t, "", args.QueueBindingKey)
-	assert.Equal(t, map[string]string{"a": "b", "c": "d"}, args.Headers)
+	assert.Equal(t, map[string]string{"a": "b", "c": "d"}, args.Args)
 	assert.Equal(t, HeaderMatchAny, args.HeaderMode)
 	assertEqualURL(t, "uri", args.AMQPURL)
 }
 
 func TestCliCreateExchange(t *testing.T) {
 	args, err := ParseCommandLineArgs(
-		[]string{"exchange", "create", "name", "--type", "topic",
+		[]string{"exchange", "create", "name", "--type", "topic", "--args=x=y",
 			"--uri", "uri"})
 
 	assert.Nil(t, err)
@@ -578,6 +579,7 @@ func TestCliCreateExchange(t *testing.T) {
 	assert.Equal(t, "topic", args.ExchangeType)
 	assert.False(t, args.Durable)
 	assert.False(t, args.Autodelete)
+	assert.Equal(t, map[string]string{"x": "y"}, args.Args)
 	assertEqualURL(t, "uri", args.AMQPURL)
 }
 

--- a/cmd/rabtap/main.go
+++ b/cmd/rabtap/main.go
@@ -137,7 +137,7 @@ func startCmdPublish(ctx context.Context, args CommandLineArgs) {
 		amqpURL:    args.AMQPURL,
 		exchange:   args.PubExchange,
 		routingKey: args.PubRoutingKey,
-		headers:    args.Headers,
+		headers:    args.Args,
 		fixedDelay: args.Delay,
 		speed:      args.Speed,
 		tlsConfig:  getTLSConfig(args.InsecureTLS, args.TLSCertFile, args.TLSKeyFile, args.TLSCaFile),
@@ -202,13 +202,14 @@ func dispatchCmd(ctx context.Context, args CommandLineArgs, tlsConfig *tls.Confi
 		cmdExchangeCreate(CmdExchangeCreateArg{amqpURL: args.AMQPURL,
 			exchange: args.ExchangeName, exchangeType: args.ExchangeType,
 			durable: args.Durable, autodelete: args.Autodelete,
-			tlsConfig: tlsConfig})
+			tlsConfig: tlsConfig, args: args.Args})
 	case ExchangeRemoveCmd:
 		cmdExchangeRemove(args.AMQPURL, args.ExchangeName, tlsConfig)
 	case QueueCreateCmd:
 		cmdQueueCreate(CmdQueueCreateArg{amqpURL: args.AMQPURL,
 			queue: args.QueueName, durable: args.Durable,
-			autodelete: args.Autodelete, tlsConfig: tlsConfig})
+			autodelete: args.Autodelete, tlsConfig: tlsConfig,
+			args: args.Args})
 	case QueueRemoveCmd:
 		cmdQueueRemove(args.AMQPURL, args.QueueName, tlsConfig)
 	case QueuePurgeCmd:
@@ -218,14 +219,14 @@ func dispatchCmd(ctx context.Context, args CommandLineArgs, tlsConfig *tls.Confi
 			amqpURL:  args.AMQPURL,
 			exchange: args.ExchangeName,
 			queue:    args.QueueName, key: args.QueueBindingKey,
-			headerMode: args.HeaderMode, headers: args.Headers,
+			headerMode: args.HeaderMode, args: args.Args,
 			tlsConfig: tlsConfig})
 	case QueueUnbindCmd:
 		cmdQueueUnbindFromExchange(CmdQueueBindArg{
 			amqpURL:  args.AMQPURL,
 			exchange: args.ExchangeName,
 			queue:    args.QueueName, key: args.QueueBindingKey,
-			headerMode: args.HeaderMode, headers: args.Headers,
+			headerMode: args.HeaderMode, args: args.Args,
 			tlsConfig: tlsConfig})
 	case ConnCloseCmd:
 		cmdConnClose(ctx, args.APIURL, args.ConnName,

--- a/pkg/exchange.go
+++ b/pkg/exchange.go
@@ -1,11 +1,13 @@
-// Copyright (C) 2017 Jan Delgado
-// RabbitMQ wire-tap.
+// rabtap - exchange management
+// Copyright (C) 2017-2021 Jan Delgado
 
 package rabtap
 
+import "github.com/streadway/amqp"
+
 // CreateExchange creates a new echange on the given channel
 func CreateExchange(session Session, exchangeName, exchangeType string,
-	durable, autoDelete bool) error {
+	durable, autoDelete bool, args amqp.Table) error {
 
 	return session.ExchangeDeclare(
 		exchangeName,
@@ -14,7 +16,7 @@ func CreateExchange(session Session, exchangeName, exchangeType string,
 		autoDelete,
 		false, // not internal
 		false, // wait for response
-		nil)
+		args)
 }
 
 // RemoveExchange removes a echange on the given channel

--- a/pkg/exchange_test.go
+++ b/pkg/exchange_test.go
@@ -47,7 +47,7 @@ func TestIntegrationAmqpExchangeCreateRemove(t *testing.T) {
 	conn, ch := testcommon.IntegrationTestConnection(t, "", "", 0, false)
 	session := Session{conn, ch}
 	defer conn.Close()
-	err = CreateExchange(session, testName, "topic", false, false)
+	err = CreateExchange(session, testName, "topic", false, false, nil)
 	assert.Nil(t, err)
 
 	// check if exchange was created

--- a/pkg/queue.go
+++ b/pkg/queue.go
@@ -1,5 +1,5 @@
-// Copyright (C) 2017 Jan Delgado
-// RabbitMQ wire-tap.
+// rabtap - queue management
+// Copyright (C) 2017-2021 Jan Delgado
 
 package rabtap
 
@@ -8,7 +8,7 @@ import "github.com/streadway/amqp"
 // CreateQueue creates a new queue
 // TODO(JD) get rid of bool types
 func CreateQueue(session Session, queueName string,
-	durable, autoDelete, exclusive bool) error {
+	durable, autoDelete, exclusive bool, args amqp.Table) error {
 
 	_, err := session.QueueDeclare(
 		queueName,
@@ -16,7 +16,7 @@ func CreateQueue(session Session, queueName string,
 		autoDelete, // auto delete
 		exclusive,  // exclusive
 		false,      // wait for response
-		nil)
+		args)
 	return err
 }
 
@@ -34,12 +34,12 @@ func PurgeQueue(session Session, queueName string) (int, error) {
 
 // BindQueueToExchange binds the given queue to the given exchange.
 func BindQueueToExchange(session Session,
-	queueName, key, exchangeName string, headers amqp.Table) error {
-	return session.QueueBind(queueName, key, exchangeName, false /* wait */, headers)
+	queueName, key, exchangeName string, args amqp.Table) error {
+	return session.QueueBind(queueName, key, exchangeName, false /* wait */, args)
 }
 
 // UnbindQueueFromExchange unbinds a queue from an exchange
 func UnbindQueueFromExchange(session Session,
-	queueName, key, exchangeName string, headers amqp.Table) error {
-	return session.QueueUnbind(queueName, key, exchangeName, headers)
+	queueName, key, exchangeName string, args amqp.Table) error {
+	return session.QueueUnbind(queueName, key, exchangeName, args)
 }

--- a/pkg/queue_test.go
+++ b/pkg/queue_test.go
@@ -51,7 +51,7 @@ func TestIntegrationAmqpPurgeQueue(t *testing.T) {
 	conn, ch := testcommon.IntegrationTestConnection(t, "", "", 0, false)
 	session := Session{conn, ch}
 	defer conn.Close()
-	err := CreateQueue(session, queueTestName, false, false, false)
+	err := CreateQueue(session, queueTestName, false, false, false, nil)
 	assert.Nil(t, err)
 
 	// publish & purge 10 messages
@@ -86,7 +86,7 @@ func TestIntegrationAmqpQueueCreateBindUnbindAndRemove(t *testing.T) {
 	conn, ch := testcommon.IntegrationTestConnection(t, "", "", 0, false)
 	session := Session{conn, ch}
 	defer conn.Close()
-	err = CreateQueue(session, queueTestName, false, false, false)
+	err = CreateQueue(session, queueTestName, false, false, false, nil)
 	assert.Nil(t, err)
 
 	// check if queue was created

--- a/pkg/subscribe_test.go
+++ b/pkg/subscribe_test.go
@@ -26,7 +26,7 @@ func TestSubscribe(t *testing.T) {
 	// we need to create the queue non-exclusive, since exclusive queues are
 	// bound to the connection which created them (other connections get
 	// error RESOURCE_LOCKED (405)).
-	CreateQueue(session, queueName, false /*durable*/, true /*ad*/, false /*excl*/)
+	CreateQueue(session, queueName, false /*durable*/, true /*ad*/, false /*excl*/, nil)
 	BindQueueToExchange(session, queueName, keyName, "subtest-direct-exchange", amqp.Table{})
 
 	finishChan := make(chan int)

--- a/pkg/tap.go
+++ b/pkg/tap.go
@@ -107,7 +107,8 @@ func (s *AmqpTap) setupTap(session Session,
 	err = CreateQueue(session, tapQueue,
 		false, // non durable
 		true,  // auto delete
-		true)  // exclusive
+		true,  // exclusive
+		nil)
 	if err != nil {
 		return "", "", err
 	}
@@ -137,7 +138,7 @@ func (s *AmqpTap) createExchangeToExchangeBinding(session Session,
 	var err error
 
 	if err := CreateExchange(session, tapExchangeName, amqp.ExchangeFanout,
-		false /* nondurable*/, true); err != nil {
+		false /* nondurable*/, true, nil); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Allows to specify e.g. the queue type with e.g. `--args=x-queue-type=quorum` 