### PR TITLE
Pass optional arguments to sub command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # Changelog for rabtap
 
+## v1.34 (2021-11-24)
+
+* new: specify multiple `--args=KEY=VALUE` options to pass additional arguments
+       to the `sub` command.
+* new: create lazy queue with `queue create ... --lazy`
+* new: specify queue type to create with `queue create ... --queue-type=TYPE`
+* new: specify offset with `--offset=OFFSET` when reading from streams
+       
 ## v1.33 (2021-11-14)
 
-* new: specify multiple `--args=key=value` options to pass additional argzuments
-       to the queue and exchange create functions.
+* new: specify multiple `--args=KEY=VALUE` options to pass additional arguments
+       to the `queue` and `exchange` commands.
        
 ## v1.32 (2021-11-13)
 

--- a/cmd/rabtap/cmd_subscribe.go
+++ b/cmd/rabtap/cmd_subscribe.go
@@ -1,12 +1,12 @@
-// Copyright (C) 2017 Jan Delgado
+// subscribe cli command handler
+// Copyright (C) 2017-2021 Jan Delgado
 
 package main
-
-// subscribe cli command handler
 
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net/url"
 
 	rabtap "github.com/jandelgado/rabtap/pkg"
@@ -22,6 +22,7 @@ type CmdSubscribeArg struct {
 	messageReceiveLoopPred MessageReceiveLoopPred
 	reject                 bool
 	requeue                bool
+	args                   rabtap.KeyValueMap
 }
 
 // cmdSub subscribes to messages from the given queue
@@ -31,21 +32,24 @@ func cmdSubscribe(ctx context.Context, cmd CmdSubscribeArg) error {
 	ctx, cancel := context.WithCancel(ctx)
 	g, ctx := errgroup.WithContext(ctx)
 
-	messageChannel := make(rabtap.TapChannel)
-	config := rabtap.AmqpSubscriberConfig{Exclusive: false, AutoAck: false}
+	config := rabtap.AmqpSubscriberConfig{
+		Exclusive: false,
+		AutoAck:   false,
+		Args:      rabtap.ToAMQPTable(cmd.args)}
 	subscriber := rabtap.NewAmqpSubscriber(config, cmd.amqpURL, cmd.tlsConfig, log)
 
-	g.Go(func() error { return subscriber.EstablishSubscription(ctx, cmd.queue, messageChannel) })
+	messageChannel := make(rabtap.TapChannel)
+	errorChannel := make(rabtap.SubscribeErrorChannel)
+	g.Go(func() error { return subscriber.EstablishSubscription(ctx, cmd.queue, messageChannel, errorChannel) })
 	g.Go(func() error {
 		acknowledger := createAcknowledgeFunc(cmd.reject, cmd.requeue)
-		err := messageReceiveLoop(ctx, messageChannel, cmd.messageReceiveFunc, cmd.messageReceiveLoopPred, acknowledger)
+		err := messageReceiveLoop(ctx, messageChannel, errorChannel, cmd.messageReceiveFunc, cmd.messageReceiveLoopPred, acknowledger)
 		cancel()
 		return err
 	})
 
 	if err := g.Wait(); err != nil {
-		log.Errorf("subscribe failed with %v", err)
-		return err
+		return fmt.Errorf("subscribe failed: %w", err)
 	}
 	return nil
 }

--- a/cmd/rabtap/cmd_subscribe.go
+++ b/cmd/rabtap/cmd_subscribe.go
@@ -34,7 +34,6 @@ func cmdSubscribe(ctx context.Context, cmd CmdSubscribeArg) error {
 
 	config := rabtap.AmqpSubscriberConfig{
 		Exclusive: false,
-		AutoAck:   false,
 		Args:      rabtap.ToAMQPTable(cmd.args)}
 	subscriber := rabtap.NewAmqpSubscriber(config, cmd.amqpURL, cmd.tlsConfig, log)
 

--- a/cmd/rabtap/command_line.go
+++ b/cmd/rabtap/command_line.go
@@ -37,7 +37,7 @@ Usage:
   rabtap (tap --uri=URI EXCHANGES)... [--saveto=DIR] [--format=FORMAT]  [--limit=NUM] [-jknsv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
   rabtap sub QUEUE [--uri URI] [--saveto=DIR] [--format=FORMAT] [--limit=NUM] 
-              [(--reject [--requeue])] [-jksvn]
+              [--args=KV]... [(--reject [--requeue])] [-jksvn]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
   rabtap pub  [--uri=URI] [SOURCE] [--exchange=EXCHANGE] [--format=FORMAT] 
               [--routingkey=KEY | (--header=KV)...]
@@ -418,6 +418,10 @@ func parseSubCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 			return result, err
 		}
 		result.Limit = limit
+	}
+	result.Args, err = parseKVListOption("--args", args)
+	if err != nil {
+		return result, err
 	}
 
 	if args["--saveto"] != nil {

--- a/cmd/rabtap/command_line.go
+++ b/cmd/rabtap/command_line.go
@@ -478,11 +478,12 @@ func parseQueueCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 		if err != nil {
 			return result, err
 		}
-		if args["--any"].(bool) {
+		switch {
+		case args["--any"].(bool):
 			result.HeaderMode = HeaderMatchAny
-		} else if args["--all"].(bool) {
+		case args["--all"].(bool):
 			result.HeaderMode = HeaderMatchAll
-		} else {
+		default:
 			result.HeaderMode = HeaderNone
 		}
 
@@ -496,11 +497,12 @@ func parseQueueCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 		if err != nil {
 			return result, err
 		}
-		if args["--any"].(bool) {
+		switch { // TODO dry
+		case args["--any"].(bool):
 			result.HeaderMode = HeaderMatchAny
-		} else if args["--all"].(bool) {
+		case args["--all"].(bool):
 			result.HeaderMode = HeaderMatchAll
-		} else {
+		default:
 			result.HeaderMode = HeaderNone
 		}
 		result.ExchangeName = args["EXCHANGE"].(string)

--- a/cmd/rabtap/command_line.go
+++ b/cmd/rabtap/command_line.go
@@ -57,8 +57,10 @@ Usage:
   rabtap queue unbind QUEUE from EXCHANGE [--uri=URI] [-kv]
               (--bindingkey=KEY | (--header=KV)... (--all|--any))
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap queue rm QUEUE [--uri=URI] [-kv] [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap queue purge QUEUE [--uri=URI] [-kv] [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
+  rabtap queue rm QUEUE [--uri=URI] [-kv] 
+              [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
+  rabtap queue purge QUEUE [--uri=URI] [-kv] 
+              [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
   rabtap conn close CONNECTION [--api=APIURI] [--reason=REASON] [-kv] 
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
   rabtap --version
@@ -123,7 +125,7 @@ Arguments and options:
  -s, --silent         suppress message output to stdout.
  --speed=FACTOR       Speed factor to use during publish [default: 1.0].
  --stats              include statistics in output of info command.
- --type=TYPE		  type of exchange [default: fanout].
+ -t, --type=TYPE		  type of exchange [default: fanout].
  --tls-cert-file=CERTFILE A Cert file to use for client authentication.
  --tls-key-file=KEYFILE   A Key file to use for client authentication.
  --tls-ca-file=CAFILE     A CA Cert file to use with TLS.

--- a/cmd/rabtap/command_line_test.go
+++ b/cmd/rabtap/command_line_test.go
@@ -457,6 +457,12 @@ func TestCliPubCmdFromStdinWithJsonFormatDeprecatedIsRecognized(t *testing.T) {
 	assert.False(t, args.InsecureTLS)
 }
 
+func TestCliSubCmdOffsetSetsStreamOffsetArg(t *testing.T) {
+	args, err := ParseCommandLineArgs([]string{"sub", "queue", "--uri=uri", "--offset=123"})
+	assert.NoError(t, err)
+	assert.Equal(t, args.Args["x-stream-offset"], "123")
+}
+
 func TestCliSubCmdInvalidFormatReturnsError(t *testing.T) {
 	_, err := ParseCommandLineArgs([]string{"sub", "queue", "--uri=uri", "--format=invalid"})
 	assert.Error(t, err)

--- a/cmd/rabtap/command_line_test.go
+++ b/cmd/rabtap/command_line_test.go
@@ -491,22 +491,25 @@ func TestCliCreateQueue(t *testing.T) {
 	args, err := ParseCommandLineArgs(
 		[]string{"queue", "create", "name", "--uri=uri", "--args=x=y"})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, QueueCreateCmd, args.Cmd)
 	assert.Equal(t, "name", args.QueueName)
 	assertEqualURL(t, "uri", args.AMQPURL)
-	assert.Equal(t, map[string]string{"x": "y"}, args.Args)
+	assert.Equal(t, map[string]string{"x": "y", "x-queue-type": "classic"}, args.Args)
 	assert.False(t, args.Durable)
 	assert.False(t, args.Autodelete)
 }
 
-func TestCliCreateDurableAutodeleteQueue(t *testing.T) {
+func TestCliCreateQueueAllOptsSet(t *testing.T) {
 	args, err := ParseCommandLineArgs(
 		[]string{"queue", "create", "name", "--uri=uri",
-			"--durable", "--autodelete"})
+			"--durable", "--autodelete", "--lazy", "--queue-type=quorum"})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, QueueCreateCmd, args.Cmd)
+	assert.Equal(t, "name", args.QueueName)
+	assertEqualURL(t, "uri", args.AMQPURL)
+	assert.Equal(t, map[string]string{"x-queue-type": "quorum", "x-queue-mode": "lazy"}, args.Args)
 	assert.True(t, args.Durable)
 	assert.True(t, args.Autodelete)
 }
@@ -515,7 +518,7 @@ func TestCliRemoveQueue(t *testing.T) {
 	args, err := ParseCommandLineArgs(
 		[]string{"queue", "rm", "name", "--uri", "uri"})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, QueueRemoveCmd, args.Cmd)
 	assert.Equal(t, "name", args.QueueName)
 	assertEqualURL(t, "uri", args.AMQPURL)
@@ -525,7 +528,7 @@ func TestCliPurgeQueue(t *testing.T) {
 	args, err := ParseCommandLineArgs(
 		[]string{"queue", "purge", "name", "--uri", "uri"})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, QueuePurgeCmd, args.Cmd)
 	assert.Equal(t, "name", args.QueueName)
 	assertEqualURL(t, "uri", args.AMQPURL)
@@ -536,7 +539,7 @@ func TestCliUnbindQueue(t *testing.T) {
 		[]string{"queue", "unbind", "queuename", "from", "exchangename",
 			"--bindingkey", "key", "--uri", "uri"})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, QueueUnbindCmd, args.Cmd)
 	assert.Equal(t, "queuename", args.QueueName)
 	assert.Equal(t, "exchangename", args.ExchangeName)
@@ -549,7 +552,7 @@ func TestCliBindQueueWithBindingKey(t *testing.T) {
 		[]string{"queue", "bind", "queuename", "to", "exchangename",
 			"--bindingkey", "key", "--uri", "uri"})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, QueueBindCmd, args.Cmd)
 	assert.Equal(t, "queuename", args.QueueName)
 	assert.Equal(t, "exchangename", args.ExchangeName)

--- a/cmd/rabtap/main.go
+++ b/cmd/rabtap/main.go
@@ -168,6 +168,7 @@ func startCmdSubscribe(ctx context.Context, args CommandLineArgs) {
 		tlsConfig:              getTLSConfig(args.InsecureTLS, args.TLSCertFile, args.TLSKeyFile, args.TLSCaFile),
 		messageReceiveFunc:     messageReceiveFunc,
 		messageReceiveLoopPred: pred,
+		args:                   args.Args,
 	})
 	failOnError(err, "error subscribing messages", os.Exit)
 }

--- a/cmd/rabtap/subscribe.go
+++ b/cmd/rabtap/subscribe.go
@@ -29,7 +29,7 @@ type MessageReceiveFuncOptions struct {
 // MessageReceiveFunc processes receiced messages from a tap.
 type MessageReceiveFunc func(rabtap.TapMessage) error
 
-//var ErrMessageLoopEnded = errors.New("message loop ended")
+// var ErrMessageLoopEnded = errors.New("message loop ended")
 
 // messageReceiveLoopPred is called once for each a message that was received.
 // If it returns true, the subscriber loop continues, otherwise the loop
@@ -94,7 +94,7 @@ func messageReceiveLoop(ctx context.Context,
 		case message, more := <-messageChan:
 			if !more {
 				log.Debug("subscribe: messageReceiveLoop: channel closed.")
-				return nil //ErrMessageLoopEnded
+				return nil // ErrMessageLoopEnded
 			}
 			log.Debugf("subscribe: messageReceiveLoop: new message %+v", message)
 

--- a/cmd/rabtap/subscribe.go
+++ b/cmd/rabtap/subscribe.go
@@ -75,6 +75,7 @@ func createAcknowledgeFunc(reject, requeue bool) AcknowledgeFunc {
 
 func messageReceiveLoop(ctx context.Context,
 	messageChan rabtap.TapChannel,
+	errorChan rabtap.SubscribeErrorChannel,
 	messageReceiveFunc MessageReceiveFunc,
 	pred MessageReceiveLoopPred,
 	acknowledger AcknowledgeFunc) error {
@@ -84,6 +85,11 @@ func messageReceiveLoop(ctx context.Context,
 		case <-ctx.Done():
 			log.Debugf("subscribe: cancel")
 			return nil
+
+		case err, more := <-errorChan:
+			if more {
+				log.Errorf("subscribe: %v", err)
+			}
 
 		case message, more := <-messageChan:
 			if !more {

--- a/cmd/rabtap/subscribe_test.go
+++ b/cmd/rabtap/subscribe_test.go
@@ -75,9 +75,10 @@ func TestCreateAcknowledgeFuncReturnedFuncCorreclyAcknowledgesTheMessage(t *test
 		msg := rabtap.TapMessage{AmqpMessage: &amqp.Delivery{Acknowledger: mock}}
 
 		// when
-		ackFunc(msg)
+		err := ackFunc(msg)
 
 		// then
+		assert.NoError(t, err)
 		assert.Equal(t, tc.isacked, mock.isAcked(), info)
 		assert.Equal(t, tc.isnacked, mock.isNacked(), info)
 		assert.Equal(t, tc.isrequeued, mock.isRequeued(), info)

--- a/inttest/rabbitmq/docker-compose.yml
+++ b/inttest/rabbitmq/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   rabbitmq:
-     image: rabbitmq:3.8-management-alpine
+     image: rabbitmq:3.9-management-alpine
      volumes:
        - ./definitions.json:/etc/rabbitmq/definitions.json:z
        - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:z

--- a/pkg/amqp_connector.go
+++ b/pkg/amqp_connector.go
@@ -55,7 +55,7 @@ func (s *AmqpConnector) Connect(ctx context.Context, worker AmqpWorkerFunc) erro
 		sub, more := <-session
 		if !more {
 			// closed. TODO propagate errors from redial()
-			return errors.New("initial connection failed")
+			return errors.New("session factory closed")
 		}
 		s.logger.Debugf("got new amqp session ...")
 		action, err := worker(ctx, sub)
@@ -63,9 +63,9 @@ func (s *AmqpConnector) Connect(ctx context.Context, worker AmqpWorkerFunc) erro
 			s.logger.Errorf("worker failed with: %v", err)
 		}
 		if !action.shouldReconnect() {
-			if errClose := sub.Connection.Close(); errClose != nil {
-				s.logger.Errorf("connection close failed: %v", errClose)
-			}
+			// if errClose := sub.Connection.Close(); errClose != nil {
+			//     s.logger.Errorf("connection close failed: %v", errClose)
+			// }
 			return err
 		}
 	}

--- a/pkg/amqp_message_loop.go
+++ b/pkg/amqp_message_loop.go
@@ -21,11 +21,6 @@ func amqpMessageLoop(
 
 	for {
 		select {
-		// case err, more := <-errInCh:
-		//     if !more {
-		//         return doReconnect, fmt.Errorf("channel closed")
-		//     }
-		//     errOutCh <- &SubscribeError{Reason: SubscribeErrorChannelError, Cause: err}
 
 		case message, more := <-inCh:
 			if !more {

--- a/pkg/amqp_message_loop.go
+++ b/pkg/amqp_message_loop.go
@@ -1,9 +1,10 @@
-// Copyright (C) 2017 Jan Delgado
+// Copyright (C) 2017-2021 Jan Delgado
 
 package rabtap
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/streadway/amqp"
@@ -12,33 +13,47 @@ import (
 // amqpMessageLoop forwards incoming amqp messages from an "in" chan to an "out"
 // chan, transforming them into TapMessage objects. Can be terminated
 // using provided ctx or by closing the in chan.
-func amqpMessageLoop(ctx context.Context,
-	out TapChannel, in <-chan interface{}) ReconnectAction {
+func amqpMessageLoop(
+	ctx context.Context,
+	outCh TapChannel,
+	errOutCh SubscribeErrorChannel,
+	inCh <-chan interface{}) (ReconnectAction, error) {
 
 	for {
 		select {
-		case message, more := <-in:
+		// case err, more := <-errInCh:
+		//     if !more {
+		//         return doReconnect, fmt.Errorf("channel closed")
+		//     }
+		//     errOutCh <- &SubscribeError{Reason: SubscribeErrorChannelError, Cause: err}
+
+		case message, more := <-inCh:
 			if !more {
-				return doReconnect
-			}
-			// in is chan interface{} because we use FanIn.Ch
-			amqpMessage, ok := message.(amqp.Delivery)
-
-			if !ok {
-				panic("amqp.Delivery expected")
+				return doReconnect, fmt.Errorf("no more messages")
 			}
 
-			received := time.Now()
-			// Avoid blocking write to out when e.g. on the other end of the
-			// channel the user pressed Ctrl+S to stop console output
-			select {
-			case <-ctx.Done():
-				return doNotReconnect
-			case out <- NewTapMessage(&amqpMessage, received):
+			switch msg := message.(type) {
+
+			case *amqp.Error:
+				// TODO ctx?
+				errOutCh <- &SubscribeError{Reason: SubscribeErrorChannelError, Cause: msg}
+
+			case amqp.Delivery:
+				received := time.Now()
+				// Avoid blocking write to out when e.g. on the other end of the
+				// channel the user pressed Ctrl+S to stop console output
+				// TODO ctx.Done really needed?
+				select {
+				case <-ctx.Done():
+					return doNotReconnect, nil
+				case outCh <- NewTapMessage(&msg, received):
+				}
+			default:
+				panic("unknown message type")
 			}
 
 		case <-ctx.Done():
-			return doNotReconnect
+			return doNotReconnect, nil
 		}
 	}
 }

--- a/pkg/amqp_message_loop_test.go
+++ b/pkg/amqp_message_loop_test.go
@@ -18,7 +18,7 @@ func TestAmqpMessageLoopPanicsWithInvalidMessage(t *testing.T) {
 	errOut := make(SubscribeErrorChannel)
 
 	go func() {
-		assert.Panics(t, func() { amqpMessageLoop(ctx, out, errOut, in) }, "did not panic")
+		assert.Panics(t, func() { _, _ = amqpMessageLoop(ctx, out, errOut, in) }, "did not panic")
 		done <- true
 	}()
 

--- a/pkg/amqp_message_loop_test.go
+++ b/pkg/amqp_message_loop_test.go
@@ -1,3 +1,4 @@
+// (c) copyright jan delgado 2017-2021
 package rabtap
 
 import (
@@ -14,9 +15,10 @@ func TestAmqpMessageLoopPanicsWithInvalidMessage(t *testing.T) {
 	out := make(TapChannel)
 	in := make(chan interface{})
 	done := make(chan bool)
+	errOut := make(SubscribeErrorChannel)
 
 	go func() {
-		assert.Panics(t, func() { amqpMessageLoop(ctx, out, in) }, "did not panic")
+		assert.Panics(t, func() { amqpMessageLoop(ctx, out, errOut, in) }, "did not panic")
 		done <- true
 	}()
 
@@ -38,9 +40,11 @@ func TestAmqpMessageLoopTerminatesWhenInputChannelIsClosed(t *testing.T) {
 	out := make(TapChannel)
 	in := make(chan interface{})
 	done := make(chan ReconnectAction)
+	errOut := make(SubscribeErrorChannel)
 
 	go func() {
-		done <- amqpMessageLoop(ctx, out, in)
+		result, _ := amqpMessageLoop(ctx, out, errOut, in)
+		done <- result
 	}()
 
 	close(in)
@@ -58,9 +62,11 @@ func TestAmqpMessageLoopCancelBlockingWrite(t *testing.T) {
 	out := make(TapChannel)
 	in := make(chan interface{}, 5)
 	done := make(chan ReconnectAction)
+	errOut := make(SubscribeErrorChannel)
 
 	go func() {
-		done <- amqpMessageLoop(ctx, out, in)
+		result, _ := amqpMessageLoop(ctx, out, errOut, in)
+		done <- result
 	}()
 
 	in <- amqp.Delivery{}
@@ -79,14 +85,64 @@ func TestAmqpMessageLoopCancelBlockingWrite(t *testing.T) {
 
 }
 
+func TestAmqpMessageLoopForwardsAMessage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	out := make(TapChannel)
+	in := make(chan interface{})
+	done := make(chan ReconnectAction)
+	errOut := make(SubscribeErrorChannel)
+
+	go func() {
+		result, _ := amqpMessageLoop(ctx, out, errOut, in)
+		done <- result
+	}()
+
+	expected := amqp.Delivery{}
+	in <- expected
+
+	select {
+	case msg := <-out:
+		assert.Equal(t, expected, *msg.AmqpMessage)
+	case <-time.After(2 * time.Second):
+		assert.Fail(t, "amqpMessageLoop() did not terminate")
+	}
+	cancel()
+}
+
+func TestAmqpMessageLoopForwardsAnError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	out := make(TapChannel)
+	in := make(chan interface{})
+	done := make(chan ReconnectAction)
+	errOut := make(SubscribeErrorChannel)
+
+	go func() {
+		result, _ := amqpMessageLoop(ctx, out, errOut, in)
+		done <- result
+	}()
+
+	expected := &amqp.Error{}
+	in <- expected
+
+	select {
+	case err := <-errOut:
+		assert.Equal(t, SubscribeError{Reason: SubscribeErrorChannelError, Cause: expected}, *err)
+	case <-time.After(2 * time.Second):
+		assert.Fail(t, "amqpMessageLoop() did not terminate")
+	}
+	cancel()
+}
+
 func TestAmqpMessageLoopCancelBlockingRead(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	out := make(TapChannel)
 	in := make(chan interface{})
 	done := make(chan ReconnectAction)
+	errOut := make(SubscribeErrorChannel)
 
 	go func() {
-		done <- amqpMessageLoop(ctx, out, in)
+		result, _ := amqpMessageLoop(ctx, out, errOut, in)
+		done <- result
 	}()
 
 	cancel()
@@ -97,5 +153,4 @@ func TestAmqpMessageLoopCancelBlockingRead(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		assert.Fail(t, "amqpMessageLoop() did not terminate")
 	}
-
 }

--- a/pkg/key_value.go
+++ b/pkg/key_value.go
@@ -1,13 +1,34 @@
 package rabtap
 
-import "github.com/streadway/amqp"
+import (
+	"strconv"
+	"time"
 
+	"github.com/streadway/amqp"
+)
+
+// KeyValueMap is a string -> string map used to store key value
+// pairs defined on the command line.
 type KeyValueMap map[string]string
 
+// ToAMQPTable converts a KeyValueMap to an amqp.Table, trying to
+// infer data types:
+// - integers
+// - timestamps in RFC3339 format
+// - strings (default)
 func ToAMQPTable(headers KeyValueMap) amqp.Table {
 	table := amqp.Table{}
+
 	for k, v := range headers {
-		table[k] = v
+		var val interface{}
+		if i, err := strconv.Atoi(v); err == nil {
+			val = i
+		} else if d, err := time.Parse(time.RFC3339, v); err == nil {
+			val = d
+		} else {
+			val = v
+		}
+		table[k] = val
 	}
 	return table
 }

--- a/pkg/key_value_test.go
+++ b/pkg/key_value_test.go
@@ -1,0 +1,27 @@
+package rabtap
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToAmqpTableInfersInteger(t *testing.T) {
+	m := KeyValueMap{"x": "123"}
+
+	assert.Equal(t, int(123), ToAMQPTable(m)["x"])
+}
+
+func TestToAmqpTableInfersRFC3339Timestamp(t *testing.T) {
+	m := KeyValueMap{"x": "2021-11-18T23:05:02-02:00"}
+	ts, _ := time.Parse(time.RFC3339, "2021-11-18T23:05:02-02:00")
+
+	assert.Equal(t, ts, ToAMQPTable(m)["x"])
+}
+
+func TestToAmqpTableFallsBackToString(t *testing.T) {
+	m := KeyValueMap{"x": "hello"}
+
+	assert.Equal(t, "hello", ToAMQPTable(m)["x"])
+}

--- a/pkg/subscribe.go
+++ b/pkg/subscribe.go
@@ -20,7 +20,6 @@ const PrefetchSize = 0
 // AmqpSubscriberConfig stores configuration of the subscriber
 type AmqpSubscriberConfig struct {
 	Exclusive bool
-	AutoAck   bool
 	Args      amqp.Table
 }
 
@@ -125,7 +124,7 @@ func (s *AmqpSubscriber) consumeMessages(session Session,
 	return session.Consume(
 		queueName,
 		"__rabtap-consumer-"+uuid.Must(uuid.NewRandom()).String()[:8], // TODO param
-		s.config.AutoAck,
+		false, // no auto-ack
 		s.config.Exclusive,
 		false, // no-local - unsupported
 		false, // wait

--- a/pkg/subscribe.go
+++ b/pkg/subscribe.go
@@ -34,7 +34,6 @@ type SubscribeErrorReason int
 
 const (
 	SubscribeErrorChannelError SubscribeErrorReason = iota
-	//SubscribeErrorSubscribeFailed
 )
 
 // SubscribeError is sent back trough the error channel when there are problems
@@ -51,8 +50,9 @@ func (s *SubscribeError) Error() string {
 	switch s.Reason {
 	case SubscribeErrorChannelError:
 		return fmt.Sprintf("channel error: %s", s.Cause)
+	default:
+		return "unexpected error"
 	}
-	return "unexpected error"
 }
 
 // NewAmqpSubscriber returns a new AmqpSubscriber object associated with the
@@ -106,7 +106,6 @@ func (s *AmqpSubscriber) createWorkerFunc(
 
 		// also subscribe to channel close notifications
 		amqpErrorCh := session.Channel.NotifyClose(make(chan *amqp.Error, 1))
-
 		fanin := NewFanin([]interface{}{ch, amqpErrorCh})
 
 		return amqpMessageLoop(ctx, outCh, errOutCh, fanin.Ch)

--- a/pkg/subscribe_test.go
+++ b/pkg/subscribe_test.go
@@ -33,7 +33,7 @@ func TestSubscribeReceivesMessages(t *testing.T) {
 
 	finishChan := make(chan int)
 
-	config := AmqpSubscriberConfig{Exclusive: false, AutoAck: true}
+	config := AmqpSubscriberConfig{Exclusive: false}
 	log := testcommon.NewTestLogger()
 	subscriber := NewAmqpSubscriber(config, testcommon.IntegrationURIFromEnv(), &tls.Config{}, log)
 	resultChannel := make(TapChannel)

--- a/pkg/subscribe_test.go
+++ b/pkg/subscribe_test.go
@@ -18,6 +18,7 @@ func TestSubscribeReceivesMessages(t *testing.T) {
 	// given
 
 	// establish sending exchange.
+	messagesPerTest := 5
 	conn, ch := testcommon.IntegrationTestConnection(t, "subtest-direct-exchange", "direct", 0, false)
 	session := Session{conn, ch}
 	defer conn.Close()
@@ -53,6 +54,7 @@ func TestSubscribeReceivesMessages(t *testing.T) {
 				finishChan <- numReceived
 				return
 			case message := <-resultChannel:
+				message.AmqpMessage.Ack(false)
 				if message.AmqpMessage != nil {
 					if string(message.AmqpMessage.Body) == "Hello" {
 						numReceived++
@@ -65,8 +67,8 @@ func TestSubscribeReceivesMessages(t *testing.T) {
 	time.Sleep(TapReadyDelay)
 
 	// when: inject messages into exchange.
-	testcommon.PublishTestMessages(t, ch, MessagesPerTest, "subtest-direct-exchange", queueName, nil)
+	testcommon.PublishTestMessages(t, ch, messagesPerTest, "subtest-direct-exchange", queueName, nil)
 
 	// then
-	requireIntFromChan(t, finishChan, MessagesPerTest)
+	requireIntFromChan(t, finishChan, messagesPerTest)
 }

--- a/pkg/tap.go
+++ b/pkg/tap.go
@@ -23,7 +23,7 @@ type AmqpTap struct {
 // NewAmqpTap returns a new AmqpTap object associated with the RabbitMQ
 // broker denoted by the uri parameter.
 func NewAmqpTap(url *url.URL, tlsConfig *tls.Config, logger Logger) *AmqpTap {
-	config := AmqpSubscriberConfig{Exclusive: true, AutoAck: true}
+	config := AmqpSubscriberConfig{Exclusive: true}
 	return &AmqpTap{
 		AmqpSubscriber: NewAmqpSubscriber(config, url, tlsConfig, logger)}
 }

--- a/pkg/tap_test.go
+++ b/pkg/tap_test.go
@@ -1,5 +1,6 @@
 // Copyright (C) 2017-2021 Jan Delgado
 // +build integration
+// TODO rewrite
 
 package rabtap
 
@@ -20,9 +21,8 @@ import (
 )
 
 const (
-	MessagesPerTest = 5
-	ResultTimeout   = time.Second * 5
-	TapReadyDelay   = time.Millisecond * 500
+	ResultTimeout = time.Second * 5
+	TapReadyDelay = time.Millisecond * 500
 )
 
 func TestGetTapQueueNameForExchange(t *testing.T) {
@@ -66,6 +66,7 @@ func verifyMessagesOnTap(t *testing.T, consumer string, numExpected int,
 				success <- numReceived
 				return
 			case message := <-resultChannel:
+				message.AmqpMessage.Ack(false)
 				if message.AmqpMessage != nil {
 					if string(message.AmqpMessage.Body) == "Hello" {
 						numReceived++
@@ -90,6 +91,8 @@ func requireIntFromChan(t *testing.T, c <-chan int, expected int) {
 
 func TestIntegrationHeadersExchange(t *testing.T) {
 
+	messagesPerTest := 5
+
 	// establish sending exchange
 	conn, ch := testcommon.IntegrationTestConnection(t, "headers-exchange", "headers", 2, true)
 	defer conn.Close()
@@ -97,7 +100,7 @@ func TestIntegrationHeadersExchange(t *testing.T) {
 	finishChan := make(chan int)
 
 	// no binding key is needed for the headers exchange
-	go verifyMessagesOnTap(t, "tap-consumer1", MessagesPerTest, "headers-exchange", "", finishChan)
+	go verifyMessagesOnTap(t, "tap-consumer1", messagesPerTest, "headers-exchange", "", finishChan)
 	time.Sleep(TapReadyDelay)
 
 	// inject messages into exchange. Each message should become visible
@@ -105,13 +108,13 @@ func TestIntegrationHeadersExchange(t *testing.T) {
 	// must provide a amqp.Table struct with the messages headers, on which
 	// routing is based. See integrationTestConnection() on how the routing
 	// header is constructed.
-	testcommon.PublishTestMessages(t, ch, MessagesPerTest, "headers-exchange", "", amqp.Table{"header1": "test0"})
+	testcommon.PublishTestMessages(t, ch, messagesPerTest, "headers-exchange", "", amqp.Table{"header1": "test0"})
 
-	requireIntFromChan(t, finishChan, MessagesPerTest)
+	requireIntFromChan(t, finishChan, messagesPerTest)
 
 	// the original messages should also be delivered.
-	testcommon.VerifyTestMessageOnQueue(t, ch, "consumer2", MessagesPerTest, "queue-0", finishChan)
-	requireIntFromChan(t, finishChan, MessagesPerTest)
+	testcommon.VerifyTestMessageOnQueue(t, ch, "consumer2", messagesPerTest, "queue-0", finishChan)
+	requireIntFromChan(t, finishChan, messagesPerTest)
 }
 
 func TestIntegrationDirectExchange(t *testing.T) {
@@ -123,21 +126,21 @@ func TestIntegrationDirectExchange(t *testing.T) {
 	finishChan := make(chan int)
 
 	// connect a test-tap and check if we received the test message
-	MessagesPerTest := MessagesPerTest
+	messagesPerTest := 5
 
-	go verifyMessagesOnTap(t, "tap-consumer1", MessagesPerTest, "direct-exchange", "queue-0", finishChan)
+	go verifyMessagesOnTap(t, "tap-consumer1", messagesPerTest, "direct-exchange", "queue-0", finishChan)
 
 	time.Sleep(TapReadyDelay)
 
 	// inject messages into exchange. Each message should become visible
 	// in the tap-exchange defined above.
-	testcommon.PublishTestMessages(t, ch, MessagesPerTest, "direct-exchange", "queue-0", nil)
+	testcommon.PublishTestMessages(t, ch, messagesPerTest, "direct-exchange", "queue-0", nil)
 
-	requireIntFromChan(t, finishChan, MessagesPerTest)
+	requireIntFromChan(t, finishChan, messagesPerTest)
 
 	// the original messages should also be delivered.
-	testcommon.VerifyTestMessageOnQueue(t, ch, "consumer2", MessagesPerTest, "queue-0", finishChan)
-	requireIntFromChan(t, finishChan, MessagesPerTest)
+	testcommon.VerifyTestMessageOnQueue(t, ch, "consumer2", messagesPerTest, "queue-0", finishChan)
+	requireIntFromChan(t, finishChan, messagesPerTest)
 }
 
 // TestIntegrationTopicExchangeTapSingleQueue tests tapping to a topic
@@ -152,26 +155,26 @@ func TestIntegrationTopicExchangeTapSingleQueue(t *testing.T) {
 	finishChan := make(chan int)
 
 	// connect a test-tap and check if we received the test message
-	MessagesPerTest := MessagesPerTest
+	messagesPerTest := 5
 
 	// tap only messages routed to queue-0
-	go verifyMessagesOnTap(t, "tap-consumer1", MessagesPerTest, "topic-exchange", "queue-0", finishChan)
+	go verifyMessagesOnTap(t, "tap-consumer1", messagesPerTest, "topic-exchange", "queue-0", finishChan)
 
 	time.Sleep(TapReadyDelay)
 
 	// inject messages into exchange. Each message should become visible
 	// in the tap-exchange defined above.
-	testcommon.PublishTestMessages(t, ch, MessagesPerTest, "topic-exchange", "queue-0", nil)
-	testcommon.PublishTestMessages(t, ch, MessagesPerTest, "topic-exchange", "queue-1", nil)
+	testcommon.PublishTestMessages(t, ch, messagesPerTest, "topic-exchange", "queue-0", nil)
+	testcommon.PublishTestMessages(t, ch, messagesPerTest, "topic-exchange", "queue-1", nil)
 
-	requireIntFromChan(t, finishChan, MessagesPerTest)
+	requireIntFromChan(t, finishChan, messagesPerTest)
 
 	// the original messages should also be delivered.
-	testcommon.VerifyTestMessageOnQueue(t, ch, "consumer2", MessagesPerTest, "queue-0", finishChan)
-	requireIntFromChan(t, finishChan, MessagesPerTest)
+	testcommon.VerifyTestMessageOnQueue(t, ch, "consumer2", messagesPerTest, "queue-0", finishChan)
+	requireIntFromChan(t, finishChan, messagesPerTest)
 
-	testcommon.VerifyTestMessageOnQueue(t, ch, "consumer3", MessagesPerTest, "queue-1", finishChan)
-	requireIntFromChan(t, finishChan, MessagesPerTest)
+	testcommon.VerifyTestMessageOnQueue(t, ch, "consumer3", messagesPerTest, "queue-1", finishChan)
+	requireIntFromChan(t, finishChan, messagesPerTest)
 }
 
 // TestIntegrationTopicExchangeTapWildcard tests tapping to an exechange
@@ -185,26 +188,26 @@ func TestIntegrationTopicExchangeTapWildcard(t *testing.T) {
 	finishChan := make(chan int)
 
 	// connect a test-tap and check if we received the test message
-	MessagesPerTest := MessagesPerTest
+	messagesPerTest := 5
 
 	// tap all messages on the exchange
-	go verifyMessagesOnTap(t, "tap-consumer1", MessagesPerTest*2, "topic-exchange", "#", finishChan)
+	go verifyMessagesOnTap(t, "tap-consumer1", messagesPerTest*2, "topic-exchange", "#", finishChan)
 
 	time.Sleep(TapReadyDelay)
 
 	// inject messages into exchange. Each message should become visible
 	// in the tap-exchange defined above.
-	testcommon.PublishTestMessages(t, ch, MessagesPerTest, "topic-exchange", "queue-0", nil)
-	testcommon.PublishTestMessages(t, ch, MessagesPerTest, "topic-exchange", "queue-1", nil)
+	testcommon.PublishTestMessages(t, ch, messagesPerTest, "topic-exchange", "queue-0", nil)
+	testcommon.PublishTestMessages(t, ch, messagesPerTest, "topic-exchange", "queue-1", nil)
 
-	requireIntFromChan(t, finishChan, MessagesPerTest*2)
+	requireIntFromChan(t, finishChan, messagesPerTest*2)
 
 	// the original messages should also be delivered.
-	testcommon.VerifyTestMessageOnQueue(t, ch, "consumer2", MessagesPerTest, "queue-0", finishChan)
-	requireIntFromChan(t, finishChan, MessagesPerTest)
+	testcommon.VerifyTestMessageOnQueue(t, ch, "consumer2", messagesPerTest, "queue-0", finishChan)
+	requireIntFromChan(t, finishChan, messagesPerTest)
 
-	testcommon.VerifyTestMessageOnQueue(t, ch, "consumer3", MessagesPerTest, "queue-1", finishChan)
-	requireIntFromChan(t, finishChan, MessagesPerTest)
+	testcommon.VerifyTestMessageOnQueue(t, ch, "consumer3", messagesPerTest, "queue-1", finishChan)
+	requireIntFromChan(t, finishChan, messagesPerTest)
 }
 
 // TestIntegrationInvalidExchange tries to tap to a non existing exhange, we


### PR DESCRIPTION
This allows e.g. to use streams when running `rabtap sub mystream --args=x-stream-offset=next`. For common arguments, shortcuts were added:
* `rabtap sub mystream --offset=next` is an alias for `--arg=x-stream-offset=next`
* `rabtap queue create ... --lazy` is an alias for  `--arg=x-queue-mode=lazy`
* `rabtap queue create ... --queue-type=quorum` is an alias for  `--arg=x-queue-type=quorum`


 
We now also listen for channel error notifications from the broker and log these as errors.
