### PR TITLE
Add subscribe idle timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v1.35 (2021-11-27)
 
 * new: new option `--idle-timeout=DURATION` added to `sub` and `tap` commands
+* chg: always wait for server notifications after pubishing, to be informed
+       on potential problems like publishing to a non existing exchange
 
 ## v1.34 (2021-11-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for rabtap
 
+## v1.35 (2021-11-27)
+
+* new: new option `--idle-timeout=DURATION` added to `sub` and `tap` commands
+
 ## v1.34 (2021-11-24)
 
 * new: specify multiple `--args=KEY=VALUE` options to pass additional arguments

--- a/README.md
+++ b/README.md
@@ -137,26 +137,29 @@ rabtap - RabbitMQ wire tap.                    github.com/jandelgado/rabtap
 
 Usage:
   rabtap -h|--help
-  rabtap info [--api=APIURI] [--consumers] [--stats] [--filter=EXPR] [--omit-empty] 
+  rabtap info [--api=APIURI] [--consumers] [--stats] [--filter=EXPR] [--omit-empty]
               [--show-default] [--mode=MODE] [--format=FORMAT] [-knv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap tap EXCHANGES [--uri=URI] [--saveto=DIR] [--format=FORMAT] [--limit=NUM] [-jknsv]
+  rabtap tap EXCHANGES [--uri=URI] [--saveto=DIR]
+              [--format=FORMAT]  [--limit=NUM] [--idle-timeout=DURATION] [-jknsv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap (tap --uri=URI EXCHANGES)... [--saveto=DIR] [--format=FORMAT]  [--limit=NUM] [-jknsv]
+  rabtap (tap --uri=URI EXCHANGES)... [--saveto=DIR]
+              [--format=FORMAT]  [--limit=NUM] [--idle-timeout=DURATION] [-jknsv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap sub QUEUE [--uri URI] [--saveto=DIR] [--format=FORMAT] [--limit=NUM] 
+  rabtap sub QUEUE [--uri URI] [--saveto=DIR] [--format=FORMAT] [--limit=NUM]
               [--offset=OFFSET] [--args=KV]... [(--reject [--requeue])] [-jksvn]
+			  [--idle-timeout=DURATION]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap pub  [--uri=URI] [SOURCE] [--exchange=EXCHANGE] [--format=FORMAT] 
+  rabtap pub  [--uri=URI] [SOURCE] [--exchange=EXCHANGE] [--format=FORMAT]
               [--routingkey=KEY | (--header=KV)...]
               [--confirms] [--mandatory] [--delay=DELAY | --speed=FACTOR] [-jkv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
   rabtap exchange create EXCHANGE [--uri=URI] [--type=TYPE] [--args=KV]... [-kv]
               [--autodelete] [--durable]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap exchange rm EXCHANGE [--uri=URI] [-kv] 
+  rabtap exchange rm EXCHANGE [--uri=URI] [-kv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap queue create QUEUE [--uri=URI] [--queue-type=TYPE] [--args=KV]... [-kv] 
+  rabtap queue create QUEUE [--uri=URI] [--queue-type=TYPE] [--args=KV]... [-kv]
               [--autodelete] [--durable] [--lazy]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
   rabtap queue bind QUEUE to EXCHANGE [--uri=URI] [-kv]
@@ -165,11 +168,11 @@ Usage:
   rabtap queue unbind QUEUE from EXCHANGE [--uri=URI] [-kv]
               (--bindingkey=KEY | (--header=KV)... (--all|--any))
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap queue rm QUEUE [--uri=URI] [-kv] 
+  rabtap queue rm QUEUE [--uri=URI] [-kv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap queue purge QUEUE [--uri=URI] [-kv] 
+  rabtap queue purge QUEUE [--uri=URI] [-kv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap conn close CONNECTION [--api=APIURI] [--reason=REASON] [-kv] 
+  rabtap conn close CONNECTION [--api=APIURI] [--reason=REASON] [-kv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
   rabtap --version
 
@@ -193,20 +196,23 @@ Arguments and options:
  --confirms           enable publisher confirms and wait for confirmations.
  --consumers          include consumers and connections in output of info command.
  --delay=DELAY        Time to wait between sending messages during publish.
-                      If not set then messages will be delayed as recorded. 
+                      If not set then messages will be delayed as recorded.
 					  The value must be suffixed with a time unit, e.g. ms, s etc.
  -d, --durable        create durable exchange/queue.
  --exchange=EXCHANGE  Optional exchange to publish to. If omitted, exchange will
                       be taken from message being published (see JSON message format).
  --filter=EXPR        Predicate for info command to filter queues [default: true]
  --format=FORMAT      * for tap, pub, sub command: format to write/read messages to console
-                        and optionally to file (when --saveto DIR is given). 
+                        and optionally to file (when --saveto DIR is given).
                         Valid options are: "raw", "json", "json-nopp". Default: raw
-                      * for info command: controls generated output format. Valid 
+                      * for info command: controls generated output format. Valid
                         options are: "text", "dot". Default: text
  -h, --help           print this help.
  --header=KV          A key value pair in the form of "key=value" used as a
                       routing- or binding-key. Can occur multiple times.
+ --idle-timeout=DURATION end reading messages when no new message was received
+                      for the given duration.  The value must be suffixed with 
+					  a time unit, e.g. ms, s etc.
  -j, --json           deprecated. Use "--format json" instead.
  -k, --insecure       allow insecure TLS connections (no certificate check).
  --lazy               create a lazy queue.
@@ -218,15 +224,15 @@ Arguments and options:
  -n, --no-color       don't colorize output (see also environment variable NO_COLOR).
  --omit-empty         don't show echanges without bindings in info command.
  --offset=OFFSET      Offset when reading from a stream. Can be 'first', 'last',
-                      'next', a duration like '10m', a RFC3339-Timestamp or 
-					  an integer index value. Basically it is an alias for 
+                      'next', a duration like '10m', a RFC3339-Timestamp or
+					  an integer index value. Basically it is an alias for
 					  '--args=x-stream-offset=OFFSET'.
  --queue-type=TYPE    type of queue [default: classic].
  --reason=REASON      reason why the connection was closed [default: closed by rabtap].
  --reject             Reject messages. Default behaviour is to acknowledge messages.
  --requeue            Instruct broker to requeue rejected message
  -r, --routingkey=KEY routing key to use in publish mode. If omitted, routing key
-                      will be taken from message being published (see JSON 
+                      will be taken from message being published (see JSON
 					  message format).
  --saveto=DIR         also save messages and metadata to DIR.
  --show-default       include default exchange in output info command.
@@ -490,8 +496,9 @@ The `sub` command reads messages from a queue or a stream. The general form
 of the `sub` command is:
 
 ```
-rabtap sub QUEUE [--uri URI] [--saveto=DIR] [--format=FORMAT] [--limit=NUM] 
-          [--offset=OFFSET] [--args=KV]... [(--reject [--requeue])] [-jksvn]
+  rabtap sub QUEUE [--uri URI] [--saveto=DIR] [--format=FORMAT] [--limit=NUM]
+              [--offset=OFFSET] [--args=KV]... [(--reject [--requeue])] [-jksvn]
+			  [--idle-timeout=DURATION]
 ```
 
 Use the `--limit=NUM` option to limit the number of received messages. If 
@@ -509,6 +516,10 @@ stream and must be any of: `first`, `last`, `next`, a numerical offset, a
 RFC3339-Timestamp or a duration specification like `10m`. Consult the RabbitMQ
 documentation for more information on [streams](https://www.rabbitmq.com/streams.html).
 
+When `--idle-timeout=DURATION` is set, the subscribe command will terminate when no new
+messages were received in the given time period. Look for the description of the 
+`--delay` option for the format of the `DURATION` parameter.
+
 Examples:
 
 * `$ rabtap sub somequeue --format=json` - will consume messages from queue
@@ -523,6 +534,8 @@ Examples:
   starting with the 50th message.
 * `rabtap sub mystream --offset=10m` - read messages from stream `mystream`
   which are aged 10 minutes or less.
+* `rabtap sub somequeue --idle-timeout=5s` - read messages from queue `somequeue`
+  and exit when there is no new message received for 5 seconds.
 
 #### Publish messages
 
@@ -550,6 +563,9 @@ consecutive recorded messages using the metadata, and delay publishing
 accordingly. To set the publishing delay to a fix value, use the `--delay`
 option. To publish without delays, use `--delay=0s`. To modify publishing speed
 use the `--speed` option, which allows to set a factor to apply to the delays.
+A delay is a sequence of decimal numbers, each with optional fraction and a
+unit suffix, such as "300ms", "-1.5h" 0or "2h45m". Valid time units are "ns",
+"us" (or "µs"), "ms", "s", "m", "h". 
 
 When the `--confirms` option is set, rabtap waits for publisher confirmations
 from the server and logs an error if a confirmation is negative or not received

--- a/cmd/rabtap/cmd_subscribe_test.go
+++ b/cmd/rabtap/cmd_subscribe_test.go
@@ -37,6 +37,7 @@ func TestCmdSubFailsEarlyWhenBrokerIsNotAvailable(t *testing.T) {
 			tlsConfig:              &tls.Config{},
 			messageReceiveFunc:     func(rabtap.TapMessage) error { return nil },
 			messageReceiveLoopPred: func(rabtap.TapMessage) bool { return true },
+			timeout:                time.Second * 10,
 		})
 		done <- true
 	}()
@@ -82,6 +83,7 @@ func TestCmdSub(t *testing.T) {
 		tlsConfig:              tlsConfig,
 		messageReceiveFunc:     receiveFunc,
 		messageReceiveLoopPred: func(rabtap.TapMessage) bool { return true },
+		timeout:                time.Second * 10,
 	})
 
 	time.Sleep(time.Second * 1)

--- a/cmd/rabtap/cmd_tap.go
+++ b/cmd/rabtap/cmd_tap.go
@@ -6,17 +6,27 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
 	rabtap "github.com/jandelgado/rabtap/pkg"
 )
 
+type CmdTapArg struct {
+	tapConfig          []rabtap.TapConfiguration
+	tlsConfig          *tls.Config
+	messageReceiveFunc MessageReceiveFunc
+	pred               MessageReceiveLoopPred
+	timeout            time.Duration
+}
+
 // cmdTap taps to the given exchanges and displays or saves the received
 // messages.
 // TODO feature: discover bindings when no binding keys are given (-> discovery.go)
-func cmdTap(ctx context.Context, tapConfig []rabtap.TapConfiguration, tlsConfig *tls.Config,
-	messageReceiveFunc MessageReceiveFunc, pred MessageReceiveLoopPred) {
+func cmdTap(
+	ctx context.Context,
+	cmd CmdTapArg) {
 
 	ctx, cancel := context.WithCancel(ctx)
 	g, ctx := errgroup.WithContext(ctx)
@@ -24,19 +34,26 @@ func cmdTap(ctx context.Context, tapConfig []rabtap.TapConfiguration, tlsConfig 
 	tapMessageChannel := make(rabtap.TapChannel)
 	errorChannel := make(rabtap.SubscribeErrorChannel)
 
-	for _, config := range tapConfig {
-		tap := rabtap.NewAmqpTap(config.AMQPURL, tlsConfig, log)
+	for _, config := range cmd.tapConfig {
+		config := config
+		tap := rabtap.NewAmqpTap(config.AMQPURL, cmd.tlsConfig, log)
 		g.Go(func() error {
 			return tap.EstablishTap(ctx, config.Exchanges, tapMessageChannel, errorChannel)
 		})
 	}
 	g.Go(func() error {
 		acknowledger := createAcknowledgeFunc(false, false) // ACK
-		err := messageReceiveLoop(ctx, tapMessageChannel, errorChannel, messageReceiveFunc, pred, acknowledger)
+		err := messageReceiveLoop(ctx,
+			tapMessageChannel,
+			errorChannel,
+			cmd.messageReceiveFunc,
+			cmd.pred,
+			acknowledger,
+			cmd.timeout)
 		cancel()
 		return err
 	})
-	if err := g.Wait(); err != nil {
+	if err := g.Wait(); err != nil && err != ErrIdleTimeout {
 		log.Errorf("tap failed with %v", err)
 	}
 }

--- a/cmd/rabtap/cmd_tap_test.go
+++ b/cmd/rabtap/cmd_tap_test.go
@@ -47,7 +47,11 @@ func TestCmdTap(t *testing.T) {
 	pred := func(rabtap.TapMessage) bool { return true }
 
 	// when
-	go cmdTap(ctx, tapConfig, &tls.Config{}, receiveFunc, pred)
+	go cmdTap(ctx, CmdTapArg{tapConfig: tapConfig,
+		tlsConfig:          &tls.Config{},
+		messageReceiveFunc: receiveFunc,
+		pred:               pred,
+		timeout:            time.Second * 10})
 
 	time.Sleep(time.Second * 1)
 	err := ch.Publish(

--- a/cmd/rabtap/command_line.go
+++ b/cmd/rabtap/command_line.go
@@ -8,6 +8,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net/url"
 	"os"
 	"regexp"
@@ -29,26 +30,29 @@ const (
 
 Usage:
   rabtap -h|--help
-  rabtap info [--api=APIURI] [--consumers] [--stats] [--filter=EXPR] [--omit-empty] 
+  rabtap info [--api=APIURI] [--consumers] [--stats] [--filter=EXPR] [--omit-empty]
               [--show-default] [--mode=MODE] [--format=FORMAT] [-knv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap tap EXCHANGES [--uri=URI] [--saveto=DIR] [--format=FORMAT] [--limit=NUM] [-jknsv]
+  rabtap tap EXCHANGES [--uri=URI] [--saveto=DIR]
+              [--format=FORMAT]  [--limit=NUM] [--idle-timeout=DURATION] [-jknsv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap (tap --uri=URI EXCHANGES)... [--saveto=DIR] [--format=FORMAT]  [--limit=NUM] [-jknsv]
+  rabtap (tap --uri=URI EXCHANGES)... [--saveto=DIR]
+              [--format=FORMAT]  [--limit=NUM] [--idle-timeout=DURATION] [-jknsv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap sub QUEUE [--uri URI] [--saveto=DIR] [--format=FORMAT] [--limit=NUM] 
+  rabtap sub QUEUE [--uri URI] [--saveto=DIR] [--format=FORMAT] [--limit=NUM]
               [--offset=OFFSET] [--args=KV]... [(--reject [--requeue])] [-jksvn]
+			  [--idle-timeout=DURATION]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap pub  [--uri=URI] [SOURCE] [--exchange=EXCHANGE] [--format=FORMAT] 
+  rabtap pub  [--uri=URI] [SOURCE] [--exchange=EXCHANGE] [--format=FORMAT]
               [--routingkey=KEY | (--header=KV)...]
               [--confirms] [--mandatory] [--delay=DELAY | --speed=FACTOR] [-jkv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
   rabtap exchange create EXCHANGE [--uri=URI] [--type=TYPE] [--args=KV]... [-kv]
               [--autodelete] [--durable]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap exchange rm EXCHANGE [--uri=URI] [-kv] 
+  rabtap exchange rm EXCHANGE [--uri=URI] [-kv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap queue create QUEUE [--uri=URI] [--queue-type=TYPE] [--args=KV]... [-kv] 
+  rabtap queue create QUEUE [--uri=URI] [--queue-type=TYPE] [--args=KV]... [-kv]
               [--autodelete] [--durable] [--lazy]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
   rabtap queue bind QUEUE to EXCHANGE [--uri=URI] [-kv]
@@ -57,11 +61,11 @@ Usage:
   rabtap queue unbind QUEUE from EXCHANGE [--uri=URI] [-kv]
               (--bindingkey=KEY | (--header=KV)... (--all|--any))
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap queue rm QUEUE [--uri=URI] [-kv] 
+  rabtap queue rm QUEUE [--uri=URI] [-kv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap queue purge QUEUE [--uri=URI] [-kv] 
+  rabtap queue purge QUEUE [--uri=URI] [-kv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
-  rabtap conn close CONNECTION [--api=APIURI] [--reason=REASON] [-kv] 
+  rabtap conn close CONNECTION [--api=APIURI] [--reason=REASON] [-kv]
               [(--tls-cert-file=CERTFILE --tls-key-file=KEYFILE)] [--tls-ca-file=CAFILE]
   rabtap --version
 
@@ -85,20 +89,23 @@ Arguments and options:
  --confirms           enable publisher confirms and wait for confirmations.
  --consumers          include consumers and connections in output of info command.
  --delay=DELAY        Time to wait between sending messages during publish.
-                      If not set then messages will be delayed as recorded. 
+                      If not set then messages will be delayed as recorded.
 					  The value must be suffixed with a time unit, e.g. ms, s etc.
  -d, --durable        create durable exchange/queue.
  --exchange=EXCHANGE  Optional exchange to publish to. If omitted, exchange will
                       be taken from message being published (see JSON message format).
  --filter=EXPR        Predicate for info command to filter queues [default: true]
  --format=FORMAT      * for tap, pub, sub command: format to write/read messages to console
-                        and optionally to file (when --saveto DIR is given). 
+                        and optionally to file (when --saveto DIR is given).
                         Valid options are: "raw", "json", "json-nopp". Default: raw
-                      * for info command: controls generated output format. Valid 
+                      * for info command: controls generated output format. Valid
                         options are: "text", "dot". Default: text
  -h, --help           print this help.
  --header=KV          A key value pair in the form of "key=value" used as a
                       routing- or binding-key. Can occur multiple times.
+ --idle-timeout=DURATION end reading messages when no new message was received
+                      for the given duration.  The value must be suffixed with 
+					  a time unit, e.g. ms, s etc.
  -j, --json           deprecated. Use "--format json" instead.
  -k, --insecure       allow insecure TLS connections (no certificate check).
  --lazy               create a lazy queue.
@@ -110,15 +117,15 @@ Arguments and options:
  -n, --no-color       don't colorize output (see also environment variable NO_COLOR).
  --omit-empty         don't show echanges without bindings in info command.
  --offset=OFFSET      Offset when reading from a stream. Can be 'first', 'last',
-                      'next', a duration like '10m', a RFC3339-Timestamp or 
-					  an integer index value. Basically it is an alias for 
+                      'next', a duration like '10m', a RFC3339-Timestamp or
+					  an integer index value. Basically it is an alias for
 					  '--args=x-stream-offset=OFFSET'.
  --queue-type=TYPE    type of queue [default: classic].
  --reason=REASON      reason why the connection was closed [default: closed by rabtap].
  --reject             Reject messages. Default behaviour is to acknowledge messages.
  --requeue            Instruct broker to requeue rejected message
  -r, --routingkey=KEY routing key to use in publish mode. If omitted, routing key
-                      will be taken from message being published (see JSON 
+                      will be taken from message being published (see JSON
 					  message format).
  --saveto=DIR         also save messages and metadata to DIR.
  --show-default       include default exchange in output info command.
@@ -256,6 +263,7 @@ type CommandLineArgs struct {
 	Limit               int64             // sub: optional limit
 	Reject              bool              // sub: reject messages
 	Requeue             bool              // sub: requeue rejectied messages
+	IdleTimeout         time.Duration     // sub: idle timeout
 	QueueName           string            // queue create, remove, bind, sub
 	QueueBindingKey     string            // queue bind
 	ExchangeName        string            // exchange name  create, remove or queue bind
@@ -408,12 +416,13 @@ func parsePubSubFormatArg(args map[string]interface{}) (string, error) {
 
 func parseSubCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 	result := CommandLineArgs{
-		Cmd:        SubCmd,
-		commonArgs: parseCommonArgs(args),
-		Reject:     args["--reject"].(bool),
-		Requeue:    args["--requeue"].(bool),
-		QueueName:  args["QUEUE"].(string),
-		Silent:     args["--silent"].(bool),
+		Cmd:         SubCmd,
+		commonArgs:  parseCommonArgs(args),
+		Reject:      args["--reject"].(bool),
+		Requeue:     args["--requeue"].(bool),
+		QueueName:   args["QUEUE"].(string),
+		Silent:      args["--silent"].(bool),
+		IdleTimeout: time.Duration(math.MaxInt64),
 	}
 
 	format, err := parsePubSubFormatArg(args)
@@ -422,6 +431,13 @@ func parseSubCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 	}
 	result.Format = format
 
+	if timeout := args["--idle-timeout"]; timeout != nil {
+		duration, err := time.ParseDuration(timeout.(string))
+		if err != nil {
+			return result, fmt.Errorf("failed to parse --idle-timeout: %w", err)
+		}
+		result.IdleTimeout = duration
+	}
 	if args["--limit"] != nil {
 		limit, err := strconv.ParseInt(args["--limit"].(string), 10, 64)
 		if err != nil {
@@ -600,10 +616,11 @@ func parsePublishCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 
 func parseTapCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 	result := CommandLineArgs{
-		Cmd:        TapCmd,
-		commonArgs: parseCommonArgs(args),
-		Silent:     args["--silent"].(bool),
-		TapConfig:  []rabtap.TapConfiguration{}}
+		Cmd:         TapCmd,
+		commonArgs:  parseCommonArgs(args),
+		Silent:      args["--silent"].(bool),
+		TapConfig:   []rabtap.TapConfiguration{},
+		IdleTimeout: time.Duration(math.MaxInt64)}
 
 	format, err := parsePubSubFormatArg(args)
 	if err != nil {
@@ -611,6 +628,13 @@ func parseTapCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 	}
 	result.Format = format
 
+	if timeout := args["--idle-timeout"]; timeout != nil {
+		duration, err := time.ParseDuration(timeout.(string))
+		if err != nil {
+			return result, fmt.Errorf("failed to parse --idle-timeout: %w", err)
+		}
+		result.IdleTimeout = duration
+	}
 	if args["--limit"] != nil {
 		limit, err := strconv.ParseInt(args["--limit"].(string), 10, 64)
 		if err != nil {

--- a/cmd/rabtap/command_line.go
+++ b/cmd/rabtap/command_line.go
@@ -366,7 +366,7 @@ func parseInfoCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 
 	var err error
 	if result.APIURL, err = parseAPIURI(args); err != nil {
-		return result, err
+		return result, fmt.Errorf("failed to parse API URL: %w", err)
 	}
 	return result, nil
 }
@@ -377,7 +377,7 @@ func parseConnCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 
 	var err error
 	if result.APIURL, err = parseAPIURI(args); err != nil {
-		return result, err
+		return result, fmt.Errorf("failed to parse API URL: %w", err)
 	}
 	if args["close"].(bool) {
 		result.Cmd = ConnCloseCmd
@@ -425,13 +425,13 @@ func parseSubCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 	if args["--limit"] != nil {
 		limit, err := strconv.ParseInt(args["--limit"].(string), 10, 64)
 		if err != nil {
-			return result, err
+			return result, fmt.Errorf("failed to parse --limit: %w", err)
 		}
 		result.Limit = limit
 	}
 	result.Args, err = parseKVListOption("--args", args)
 	if err != nil {
-		return result, err
+		return result, fmt.Errorf("failed to parse --args: %w", err)
 	}
 
 	if args["--saveto"] != nil {
@@ -439,7 +439,7 @@ func parseSubCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 		result.SaveDir = &saveDir
 	}
 	if result.AMQPURL, err = parseAMQPURL(args); err != nil {
-		return result, err
+		return result, fmt.Errorf("failed to parse AMQP URL: %w", err)
 	}
 	if offset := args["--offset"]; offset != nil {
 		result.Args["x-stream-offset"] = offset.(string)
@@ -479,7 +479,7 @@ func parseQueueCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 	}
 	var err error
 	if result.AMQPURL, err = parseAMQPURL(args); err != nil {
-		return result, err
+		return result, fmt.Errorf("failed to parse AMQP URL: %w", err)
 	}
 	switch {
 	case args["create"].(bool):
@@ -488,7 +488,7 @@ func parseQueueCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 		result.Autodelete = args["--autodelete"].(bool)
 		result.Args, err = parseKVListOption("--args", args)
 		if err != nil {
-			return result, nil
+			return result, fmt.Errorf("failed to parse --args: %w", err)
 		}
 		result.Args["x-queue-type"] = args["--queue-type"].(string)
 		if args["--lazy"].(bool) {
@@ -504,7 +504,7 @@ func parseQueueCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 
 		result.Args, err = parseKVListOption("--header", args)
 		if err != nil {
-			return result, err
+			return result, fmt.Errorf("failed to parse --header: %w", err)
 		}
 		result.HeaderMode = parseHeaderMode(args)
 		result.ExchangeName = args["EXCHANGE"].(string)
@@ -515,7 +515,7 @@ func parseQueueCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 		result.QueueBindingKey = parseBindingKey(args)
 		result.Args, err = parseKVListOption("--header", args)
 		if err != nil {
-			return result, err
+			return result, fmt.Errorf("failed to parse --header: %w", err)
 		}
 		result.HeaderMode = parseHeaderMode(args)
 		result.ExchangeName = args["EXCHANGE"].(string)
@@ -542,7 +542,7 @@ func parseExchangeCmdArgs(args map[string]interface{}) (CommandLineArgs, error) 
 		result.Autodelete = args["--autodelete"].(bool)
 		result.Args, err = parseKVListOption("--args", args)
 		if err != nil {
-			return result, err
+			return result, fmt.Errorf("failed to parse --args: %w", err)
 		}
 	case args["rm"].(bool):
 		result.Cmd = ExchangeRemoveCmd
@@ -572,7 +572,7 @@ func parsePublishCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 	}
 	result.Args, err = parseKVListOption("--header", args)
 	if err != nil {
-		return result, err
+		return result, fmt.Errorf("failed to parse --header: %w", err)
 	}
 	if args["--routingkey"] != nil {
 		routingKey := args["--routingkey"].(string)
@@ -592,7 +592,7 @@ func parsePublishCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 	if args["--speed"] != nil {
 		result.Speed, err = strconv.ParseFloat(args["--speed"].(string), 64)
 		if err != nil {
-			return result, err
+			return result, fmt.Errorf("failed to parse --speed: %w", err)
 		}
 	}
 	return result, nil
@@ -614,7 +614,7 @@ func parseTapCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 	if args["--limit"] != nil {
 		limit, err := strconv.ParseInt(args["--limit"].(string), 10, 64)
 		if err != nil {
-			return result, err
+			return result, fmt.Errorf("failed to parse --limit: %w", err)
 		}
 		result.Limit = limit
 	}
@@ -630,11 +630,11 @@ func parseTapCmdArgs(args map[string]interface{}) (CommandLineArgs, error) {
 		// is used from the RABTAP_AMQPURI environment variable.
 		amqpURL, err := getAMQPURL(amqpURLs, i)
 		if err != nil {
-			return result, err
+			return result, fmt.Errorf("failed to parse AMQP URL: %w", err)
 		}
 		tapConfig, err := rabtap.NewTapConfiguration(amqpURL, exchange)
 		if err != nil {
-			return result, err
+			return result, fmt.Errorf("failed to parse tap configuration: %w", err)
 		}
 		result.TapConfig = append(result.TapConfig, *tapConfig)
 	}

--- a/cmd/rabtap/main.go
+++ b/cmd/rabtap/main.go
@@ -169,6 +169,7 @@ func startCmdSubscribe(ctx context.Context, args CommandLineArgs) {
 		messageReceiveFunc:     messageReceiveFunc,
 		messageReceiveLoopPred: pred,
 		args:                   args.Args,
+		timeout:                args.IdleTimeout,
 	})
 	failOnError(err, "error subscribing messages", os.Exit)
 }
@@ -185,8 +186,14 @@ func startCmdTap(ctx context.Context, args CommandLineArgs) {
 	messageReceiveFunc, err := createMessageReceiveFunc(opts)
 	failOnError(err, "options", os.Exit)
 	pred := createCountingMessageReceivePred(args.Limit)
-	cmdTap(ctx, args.TapConfig, getTLSConfig(args.InsecureTLS, args.TLSCertFile, args.TLSKeyFile, args.TLSCaFile),
-		messageReceiveFunc, pred)
+	cmdTap(ctx,
+		CmdTapArg{
+			tapConfig:          args.TapConfig,
+			tlsConfig:          getTLSConfig(args.InsecureTLS, args.TLSCertFile, args.TLSKeyFile, args.TLSCaFile),
+			messageReceiveFunc: messageReceiveFunc,
+			pred:               pred,
+			timeout:            args.IdleTimeout,
+		})
 }
 
 func dispatchCmd(ctx context.Context, args CommandLineArgs, tlsConfig *tls.Config) {

--- a/pkg/publish.go
+++ b/pkg/publish.go
@@ -13,7 +13,7 @@ import (
 )
 
 const timeoutWaitACK = time.Second * 2
-const timeoutWaitServer = time.Second * 1
+const timeoutWaitServer = time.Millisecond * 500
 
 // PublishMessage is a message to be published by AmqpPublish via
 // a PublishChannel
@@ -136,10 +136,6 @@ func (s *AmqpPublish) createWorkerFunc(
 		// wait a while for outstanding errors and returned messages
 		// since these can arrive after we finished publishing.
 		defer func() {
-
-			if !s.mandatory {
-				return
-			}
 
 			s.logger.Debugf("waiting for pending server messages ... ")
 			timeout := time.After(timeoutWaitServer)


### PR DESCRIPTION
Add a `--idle-timeout=DURATION` option for the `sub` and `tap` commands (#56)
When set, subscribe or tap will end when no new message is received for the given duration.