### PR TITLE
Update Arch Linux AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Pre-compiled binaries can be downloaded for multiple platforms from the
 Rabtap can be installed from the Arch Linux User Repository (AUR):
 
 ```console
-$ yay -S rabtap-bin
+$ yay -S rabtap
 ```
 
 ### Installation from source


### PR DESCRIPTION
I recently added a non-bin version of rabtap to the AUR ([link](https://aur.archlinux.org/packages/rabtap)).

I opted to remove the reference to the rabtap-bin package as it was marked as out-of-date in April 2022, but has not been updated.